### PR TITLE
Configure Go cache paths

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,9 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: |
+          go.work.sum
+          ${{ matrix.modules }}/go.sum
 
     - name: Install xsltproc
       run: sudo apt-get install -y xsltproc


### PR DESCRIPTION
Try to fix the warning in GitHub actions logs about missing Go dependency files.