### PR TITLE
Echo ReasonForMessage in Supplying Agency Confirmation Message

### DIFF
--- a/illmock/app/app.go
+++ b/illmock/app/app.go
@@ -474,7 +474,7 @@ func (app *MockApp) handleIso18626SupplyingAgencyMessage(illMessage *iso18626.Is
 		return
 	}
 	resmsg := createSupplyingAgencyResponse(supplyingAgencyMessage, iso18626.TypeMessageStatusOK, nil, nil)
-	reason := iso18626.TypeReasonForMessageRequestResponse
+	reason := supplyingAgencyMessage.MessageInfo.ReasonForMessage
 	resmsg.SupplyingAgencyMessageConfirmation.ReasonForMessage = &reason
 	app.writeIso18626Response(resmsg, w, role.Requester, header)
 	if supplyingAgencyMessage.StatusInfo.Status == iso18626.TypeStatusLoaned {


### PR DESCRIPTION
Was hard-coded to "RequestResponse" before.