### PR TITLE
No Must on network calls. Code coverage 100% again

### DIFF
--- a/illmock/app/app.go
+++ b/illmock/app/app.go
@@ -197,14 +197,14 @@ func healthHandler() http.HandlerFunc {
 func error400Handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		utils.Must(w.Write([]byte("Bad request")))
+		netutil.WriteHttpResponse(w, []byte("Bad request"))
 	}
 }
 
 func error500Handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		utils.Must(w.Write([]byte("Internal server error")))
+		netutil.WriteHttpResponse(w, []byte("Internal server error"))
 	}
 }
 

--- a/illmock/app/app_test.go
+++ b/illmock/app/app_test.go
@@ -264,6 +264,18 @@ func TestService(t *testing.T) {
 		assert.Equal(t, 405, resp.StatusCode)
 	})
 
+	t.Run("400 handler", func(t *testing.T) {
+		resp, err := http.Get(url + "/iso18626/error400")
+		assert.Nil(t, err)
+		assert.Equal(t, 400, resp.StatusCode)
+	})
+
+	t.Run("500 handler", func(t *testing.T) {
+		resp, err := http.Get(url + "/iso18626/error500")
+		assert.Nil(t, err)
+		assert.Equal(t, 500, resp.StatusCode)
+	})
+
 	t.Run("flows handler: ok", func(t *testing.T) {
 		resp, err := http.Get(apiUrl)
 		assert.Nil(t, err)

--- a/illmock/netutil/write_response.go
+++ b/illmock/netutil/write_response.go
@@ -10,7 +10,6 @@ import (
 var log *slog.Logger = slogwrap.SlogWrap()
 
 func WriteHttpResponse(w http.ResponseWriter, buf []byte) {
-	w.WriteHeader(http.StatusOK)
 	_, err := w.Write(buf)
 	if err != nil {
 		log.Warn("writeResponse", "error", err.Error())


### PR DESCRIPTION
Avoid program shutdown on network failure.