### PR TITLE
illmock requester #RETRYKEEPID# option

### DIFF
--- a/illmock/README.md
+++ b/illmock/README.md
@@ -84,8 +84,8 @@ The following values are recognized:
   * `#RENEW#` the requester will send a `Renew` request to the supplier upon receiving an `Overdue` message.
   For a sample, refer to `examples/renew-req.xml`.
 
-  * `#NEWID` the requester creates a new RequestingAgencyRequestId when sending a retry request.
-  If not given, the same RequestingAgencyRequestId is used (thus being equal to RequestingAgencyPreviousRequestId)
+  * `#RETRYKEEPID` the requester uses existing RequestingAgencyRequestId when sending a retry request. If not
+  given, a new RequestingAgencyRequestId is created (thus being different from RequestingAgencyPreviousRequestId)
 
 # ILL flows
 

--- a/illmock/app/app_test.go
+++ b/illmock/app/app_test.go
@@ -782,6 +782,7 @@ func TestService(t *testing.T) {
 
 	t.Run("Patron request retry LoanCondition", func(t *testing.T) {
 		msg := createPatronRequest()
+		msg.Request.ServiceInfo.Note = "#RETRYKEEPID#"
 		ret := runScenario(t, isoUrl, apiUrl, msg, "RETRY:COND_LOANED", 16)
 
 		m := ret[1].Message
@@ -811,6 +812,7 @@ func TestService(t *testing.T) {
 
 	t.Run("Patron request retry CostExceedsMaxCost", func(t *testing.T) {
 		msg := createPatronRequest()
+		msg.Request.ServiceInfo.Note = "#RETRYKEEPID#"
 		ret := runScenario(t, isoUrl, apiUrl, msg, "RETRY:COST_LOANED", 16)
 
 		m := ret[1].Message
@@ -843,6 +845,7 @@ func TestService(t *testing.T) {
 
 	t.Run("Patron request retry OnLoan", func(t *testing.T) {
 		msg := createPatronRequest()
+		msg.Request.ServiceInfo.Note = "#RETRYKEEPID#"
 		ret := runScenario(t, isoUrl, apiUrl, msg, "RETRY:ONLOAN_LOANED", 16)
 
 		m := ret[1].Message
@@ -872,7 +875,6 @@ func TestService(t *testing.T) {
 
 	t.Run("Patron request retry OnLoan newid", func(t *testing.T) {
 		msg := createPatronRequest()
-		msg.Request.ServiceInfo.Note = "#NEWID#"
 		ret := runScenario2(t, isoUrl, apiUrl, msg, "RETRY:ONLOAN_LOANED", 16)
 
 		assert.Len(t, ret, 2)

--- a/illmock/app/requester.go
+++ b/illmock/app/requester.go
@@ -16,7 +16,7 @@ import (
 type requesterInfo struct {
 	cancel      bool
 	renew       bool
-	newid       bool
+	retryKeepId bool
 	received    bool
 	supplierUrl string
 	request     *iso18626.Request
@@ -77,7 +77,7 @@ func (app *MockApp) handlePatronRequest(illMessage *iso18626.Iso18626MessageNS, 
 	// ServiceInfo != nil already
 	cancel := illRequest.ServiceInfo.Note == "#CANCEL#"
 	renew := illRequest.ServiceInfo.Note == "#RENEW#"
-	newid := illRequest.ServiceInfo.Note == "#NEWID#"
+	retryKeepId := illRequest.ServiceInfo.Note == "#RETRYKEEPID#"
 
 	// patron may omit RequestingAgencyRequestId
 	if header.RequestingAgencyRequestId == "" {
@@ -103,7 +103,7 @@ func (app *MockApp) handlePatronRequest(illMessage *iso18626.Iso18626MessageNS, 
 		supplierUrl: app.peerUrl,
 		cancel:      cancel,
 		renew:       renew,
-		newid:       newid,
+		retryKeepId: retryKeepId,
 		request:     msg.Request,
 	}
 	for _, supplierInfo := range illRequest.SupplierInfo {
@@ -268,7 +268,7 @@ func (app *MockApp) handleIso18626SupplyingAgencyMessage(illMessage *iso18626.Is
 	case iso18626.TypeStatusRetryPossible:
 		prevId := header.RequestingAgencyRequestId
 		newId := prevId
-		if state.newid {
+		if !state.retryKeepId {
 			header.RequestingAgencyRequestId = prevId
 			requester.delete(header)
 


### PR DESCRIPTION
If given, the requester creates a new RequestingAgencyRequestId when sending a retry request.