### PR TITLE
CROSSLINK-103: TestRequestRETRY_COST fails sometimes

### DIFF
--- a/broker/test/utils.go
+++ b/broker/test/utils.go
@@ -25,7 +25,7 @@ func GetNow() pgtype.Timestamp {
 }
 
 func WaitForPredicateToBeTrue(predicate func() bool) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
 
 	ticker := time.NewTicker(20 * time.Millisecond) // Check every 20ms


### PR DESCRIPTION
The test takes almost two seconds to run. Increase wait time from 2 to 4 seconds.