### PR TITLE
illmock: directory service query parameter peer_url

### DIFF
--- a/illmock/app/app_test.go
+++ b/illmock/app/app_test.go
@@ -1317,6 +1317,36 @@ func TestService(t *testing.T) {
 		assert.Equal(t, "Woollahra Library and Information Service / Double Bay Central Library", response.Items[1].Name)
 	})
 
+	t.Run("directory entries cql=ISIL:AU-NWOOL ok peerUrl", func(t *testing.T) {
+		resp, err := http.Get(directoryUrl + "?cql=symbol%3DISIL%3AAU-NWOOL&peer_url=http%3A%2F%2Flocalhost%3A1234")
+		assert.Nil(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		buf, err := io.ReadAll(resp.Body)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		var response directory.EntriesResponse
+		err = json.Unmarshal(buf, &response)
+		assert.Nil(t, err)
+		assert.Len(t, response.Items, 2)
+		assert.Equal(t, 2, *response.ResultInfo.TotalRecords)
+		assert.Equal(t, "Woollahra Library and Information Service", response.Items[0].Name)
+		assert.Equal(t, "http://localhost:1234", (*response.Items[0].Endpoints)[0].Address)
+		assert.Equal(t, "Woollahra Library and Information Service / Double Bay Central Library", response.Items[1].Name)
+	})
+
+	t.Run("directory entries cql=ISIL:AU-NWOOL bad peerUrl", func(t *testing.T) {
+		resp, err := http.Get(directoryUrl + "?cql=symbol%3DISIL%3AAU-NWOOL&peer_url=foo")
+		assert.Nil(t, err)
+
+		assert.Equal(t, 400, resp.StatusCode)
+		assert.Equal(t, "text/plain", resp.Header.Get("Content-Type"))
+		buf, err := io.ReadAll(resp.Body)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+		assert.Contains(t, string(buf), "peerUrl must start with http:// or https://")
+	})
+
 	t.Run("directory entries cql any sym3", func(t *testing.T) {
 		resp, err := http.Get(directoryUrl + "?cql=symbol%20any%20sym3")
 		assert.Nil(t, err)

--- a/illmock/directory/directory_api.yaml
+++ b/illmock/directory/directory_api.yaml
@@ -24,11 +24,17 @@ paths:
             format: int32
         - name: offset
           in: query
-          description: maximum number of results to return
+          description: offset of first entry
           required: false
           schema:
             type: integer
             format: int32
+        - name: peer_url
+          in: query
+          description: override url in result
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: Entry list response


### PR DESCRIPTION
When set, all address values are set to this value.