### PR TITLE
DEVOPS-5885 organizationId to directory schema

### DIFF
--- a/illmock/directory/directory_api.yaml
+++ b/illmock/directory/directory_api.yaml
@@ -199,6 +199,8 @@ components:
           type: string
         description:
           type: string
+        organizationId:
+          type: string
         contactName:
           type: string
         email:

--- a/illmock/directory/examples/directory.json
+++ b/illmock/directory/examples/directory.json
@@ -4,6 +4,7 @@
       "id": "d4cd7068-a9f4-5f3b-8eea-1a169eb71eb2",
       "name": "Test tenant TTTZ",
       "description": "tttz",
+      "organizationId": "999999",
       "type": "institution",
       "email": "test@example.com",
       "hrid": "TTTZ",


### PR DESCRIPTION
Trove requires organization identifier for Peer-to-Peer tier billing [DEVOPS-5885](https://index-data.atlassian.net/browse/DEVOPS-5885)

[DEVOPS-5885]: https://index-data.atlassian.net/browse/DEVOPS-5885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ