### PR TITLE
Fix last_signal migration

### DIFF
--- a/broker/migrations/008_last_signal_in_event.up.sql
+++ b/broker/migrations/008_last_signal_in_event.up.sql
@@ -1,1 +1,5 @@
-ALTER TABLE event ADD COLUMN last_signal VARCHAR NOT NULL;
+ALTER TABLE event ADD COLUMN last_signal VARCHAR DEFAULT '';
+
+UPDATE event SET last_signal = '';
+
+ALTER TABLE event ALTER COLUMN last_signal SET NOT NULL;


### PR DESCRIPTION
Did not set a default value.

It appears there's a problem going from 7 to 8 in DB version. 

```
k logs  crosslink-broker-65d6f96685-dgw7l 
time=2025-06-05T15:19:38.621Z level=INFO msg="starting CrossLink-Broker/d4b5441" process=ff6e6630-2f2a-4e54-a589-3655c1a91648
time=2025-06-05T15:19:38.633Z level=ERROR msg="DB migration failed" process=ff6e6630-2f2a-4e54-a589-3655c1a91648 error="failed to run migration: Dirty database version 8. Fix and force version." versionFrom=8 versionTo=0 dirty=true
time=2025-06-05T15:19:38.636Z level=INFO msg="event_bus: successfully connected and listening to channel crosslink_channel" process=ff968586-f70e-4d07-8bf6-b5db67e2ad59
time=2025-06-05T15:19:38.637Z level=INFO msg="HTTP server started on port 8080" process=ff6e6630-2f2a-4e54-a589-3655c1a91648
time=2025-06-05T15:20:27.282Z level=ERROR msg="DB TX error and rollback" process=ff968586-f70e-4d07-8bf6-b5db67e2ad59 error="ERROR: column \"last_signal\" of relation \"event\" does not exist (SQLSTATE 42703)"

```


