### PR TITLE
migrations: back to version 7 if 8 is dirty

### DIFF
--- a/broker/dbutil/dbutil.go
+++ b/broker/dbutil/dbutil.go
@@ -30,7 +30,13 @@ func RunMigrateScripts(migrateDir, connStr string) (uint, uint, bool, error) {
 	if err != nil && err != migrate.ErrNilVersion {
 		return versionFrom, versionTo, dirty, fmt.Errorf("failed to get migration version: %w", err)
 	}
-
+	if dirty && versionFrom == 8 {
+		// we know that initial version of version 8 was bad, so we force it to version 7
+		err = m.Force(7)
+		if err != nil {
+			return versionFrom, versionTo, dirty, fmt.Errorf("failed to force migration to version 7: %w", err)
+		}
+	}
 	// Migrate up
 	err = m.Up()
 	if err != nil && err != migrate.ErrNoChange {


### PR DESCRIPTION
Presumably last_signal column was not yet added.