### PR TITLE
DEVOPS-2662 Upgrade Workflow Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,7 +77,7 @@ jobs:
             type=sha
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ hashFiles(matrix.dockerfile) }}


### PR DESCRIPTION
Only upgrading actions/cache version. All others are up-to-date.

Except golangci/golangci-lint-action v6
Will investigate that later with a separate PR. (Using v8 at mod-reporting.)