### PR TITLE
Always confirm suspended requester message

### DIFF
--- a/broker/service/workflow.go
+++ b/broker/service/workflow.go
@@ -114,7 +114,6 @@ func (w *WorkflowManager) OnMessageSupplierComplete(ctx extctx.ExtendedContext, 
 		extctx.Must(ctx, func() (string, error) {
 			return w.eventBus.CreateTaskBroadcast(event.IllTransactionID, events.EventNameConfirmRequesterMsg, events.EventData{}, &event.ID)
 		}, "")
-		return
 	} else if event.EventStatus != events.EventStatusSuccess {
 		// if the last requester action was Request and messaging supplier failed, we try next supplier
 		extctx.Must(ctx, func() (string, error) {


### PR DESCRIPTION
Check the last requester action on the transaction rather than on selected supplier This ensures that even upon failure when sending a message to supplier, the  pending requester message is confirmed.

There is a small change in logic because of this: selecting next supplier when messaging the old one fails will now only resume if the last requester action is Request. E.g if the requester sends a notification to the old supplier and that message fails to deliver the request will be stuck with the supplier until the supplier takes action.

We may need a special message to select a new supplier.