### PR TITLE
Improve event bus logging and context handling

### DIFF
--- a/broker/client/client.go
+++ b/broker/client/client.go
@@ -62,12 +62,12 @@ func CreateIso18626ClientWithHttpClient(client *http.Client) Iso18626Client {
 
 func (c *Iso18626Client) MessageRequester(ctx extctx.ExtendedContext, event events.Event) {
 	ctx = ctx.WithArgs(ctx.LoggerArgs().WithComponent(CLIENT_COMP))
-	c.eventBus.ProcessTask(ctx, event, c.createAndSendSupplyingAgencyMessage)
+	_, _ = c.eventBus.ProcessTask(ctx, event, c.createAndSendSupplyingAgencyMessage)
 }
 
 func (c *Iso18626Client) MessageSupplier(ctx extctx.ExtendedContext, event events.Event) {
 	ctx = ctx.WithArgs(ctx.LoggerArgs().WithComponent(CLIENT_COMP))
-	c.eventBus.ProcessTask(ctx, event, c.createAndSendRequestOrRequestingAgencyMessage)
+	_, _ = c.eventBus.ProcessTask(ctx, event, c.createAndSendRequestOrRequestingAgencyMessage)
 }
 
 func (c *Iso18626Client) createAndSendSupplyingAgencyMessage(ctx extctx.ExtendedContext, event events.Event) (events.EventStatus, *events.EventResult) {

--- a/broker/service/supplierlocator.go
+++ b/broker/service/supplierlocator.go
@@ -36,12 +36,12 @@ func CreateSupplierLocator(eventBus events.EventBus, illRepo ill_db.IllRepo, dir
 
 func (s *SupplierLocator) LocateSuppliers(ctx extctx.ExtendedContext, event events.Event) {
 	ctx = ctx.WithArgs(ctx.LoggerArgs().WithComponent(COMP))
-	s.eventBus.ProcessTask(ctx, event, s.locateSuppliers)
+	_, _ = s.eventBus.ProcessTask(ctx, event, s.locateSuppliers)
 }
 
 func (s *SupplierLocator) SelectSupplier(ctx extctx.ExtendedContext, event events.Event) {
 	ctx = ctx.WithArgs(ctx.LoggerArgs().WithComponent(COMP))
-	s.eventBus.ProcessTask(ctx, event, s.selectSupplier)
+	_, _ = s.eventBus.ProcessTask(ctx, event, s.selectSupplier)
 }
 
 func (s *SupplierLocator) locateSuppliers(ctx extctx.ExtendedContext, event events.Event) (events.EventStatus, *events.EventResult) {


### PR DESCRIPTION
Ensure all logging is done via the event bus context and errors are forwarded to the caller for context-specific logging. Drop hard-coded labels.