### PR TITLE
Use external types in OpenAPI

### DIFF
--- a/broker/api/api-handler.go
+++ b/broker/api/api-handler.go
@@ -13,8 +13,6 @@ import (
 	"github.com/indexdata/crosslink/broker/service"
 	"github.com/indexdata/crosslink/directory"
 
-	"github.com/indexdata/go-utils/utils"
-
 	"github.com/google/uuid"
 	icql "github.com/indexdata/cql-go/cql"
 	"github.com/indexdata/cql-go/pgcql"
@@ -676,10 +674,8 @@ func ToApiEvent(event events.Event, illId string, prId *string) oapi.Event {
 		ParentID:         toString(event.ParentID),
 		PatronRequestID:  prId,
 	}
-	eventData := utils.Must(common.StructToMap(event.EventData))
-	api.EventData = &eventData
-	resultData := utils.Must(common.StructToMap(event.ResultData))
-	api.ResultData = &resultData
+	api.EventData = &event.EventData
+	api.ResultData = &event.ResultData
 	return api
 }
 
@@ -723,7 +719,7 @@ func toApiIllTransaction(r *http.Request, trans ill_db.IllTransaction) oapi.IllT
 	if trans.RequesterID.Valid {
 		api.RequesterPeerLink = toLink(r, PEERS_PATH, trans.RequesterID.String, "")
 	}
-	api.IllTransactionData = utils.Must(common.StructToMap(trans.IllTransactionData))
+	api.IllTransactionData = trans.IllTransactionData
 	return api
 }
 
@@ -754,11 +750,7 @@ func toApiPeer(peer ill_db.Peer, symbols []ill_db.Symbol, branchSymbols []ill_db
 		peer.BrokerMode = string(adapter.GetBrokerMode(adapter.GetVendorFromUrl(peer.Url)))
 	}
 
-	var customData map[string]interface{}
-	if bytes, err := json.Marshal(peer.CustomData); err == nil {
-		// If unmarshalling fails, customData remains nil
-		_ = json.Unmarshal(bytes, &customData)
-	}
+	customData := peer.CustomData
 
 	return oapi.Peer{
 		Id:            peer.ID,
@@ -798,13 +790,7 @@ func toApiBrokerMode(brokerMode string) oapi.PeerBrokerMode {
 func toDbPeer(peer oapi.Peer) ill_db.Peer {
 	var entry directory.Entry
 	if peer.CustomData != nil {
-		bytes, err := json.Marshal(*peer.CustomData)
-		if err == nil {
-			err = json.Unmarshal(bytes, &entry)
-		}
-		if err != nil {
-			entry = directory.Entry{}
-		}
+		entry = *peer.CustomData
 	}
 	httpHeaders := make(map[string]string)
 	if peer.HttpHeaders != nil {

--- a/broker/oapi/cfg.yaml
+++ b/broker/oapi/cfg.yaml
@@ -4,7 +4,8 @@ output-options:
   exclude-tags:
     - patron-requests-api
     - sse-api
+  overlay:
+    path: oapi/overlay.yaml
 generate:
   models: true
   std-http-server: true
-

--- a/broker/oapi/overlay.yaml
+++ b/broker/oapi/overlay.yaml
@@ -1,0 +1,25 @@
+overlay: 1.0.0
+info:
+  title: Object field codegen overrides
+  version: 0.0.0
+actions:
+  - target: $.components.schemas.Event.properties.eventData
+    update:
+      x-go-type: events.EventData
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/broker/events
+  - target: $.components.schemas.Event.properties.resultData
+    update:
+      x-go-type: events.EventResult
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/broker/events
+  - target: $.components.schemas.IllTransaction.properties.illTransactionData
+    update:
+      x-go-type: ill_db.IllTransactionData
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/broker/ill_db
+  - target: $.components.schemas.Peer.properties.customData
+    update:
+      x-go-type: directory.Entry
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/directory

--- a/broker/oapi/pr-cfg.yaml
+++ b/broker/oapi/pr-cfg.yaml
@@ -3,6 +3,8 @@ output: patron_request/proapi/pr-openapi_gen.go
 output-options:
   include-tags:
     - patron-requests-api
+  overlay:
+    path: oapi/pr-overlay.yaml
 generate:
   models: true
   std-http-server: true

--- a/broker/oapi/pr-overlay.yaml
+++ b/broker/oapi/pr-overlay.yaml
@@ -1,0 +1,15 @@
+overlay: 1.0.0
+info:
+  title: Patron request codegen overrides
+  version: 0.0.0
+actions:
+  - target: $.components.schemas.PatronRequest.properties.illRequest
+    update:
+      x-go-type: iso18626.Request
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/iso18626
+  - target: $.components.schemas.CreatePatronRequest.properties.illRequest
+    update:
+      x-go-type: iso18626.Request
+      x-go-type-import:
+        path: github.com/indexdata/crosslink/iso18626

--- a/broker/patron_request/api/api-handler.go
+++ b/broker/patron_request/api/api-handler.go
@@ -653,7 +653,7 @@ func prepareAndValidateIllRequest(
 	creationTime time.Time,
 ) (iso18626.Request, error) {
 	if reflect.ValueOf(rawIllRequest).IsZero() {
-		return iso18626.Request{}, fmt.Errorf("%w: missing required illRequest payload", errInvalidPatronRequest)
+		return iso18626.Request{}, fmt.Errorf("%w: illRequest must not be empty", errInvalidPatronRequest)
 	}
 	illRequest := rawIllRequest
 	suppSymbolType, suppSymbolValue, err := parseAgencySymbol(brokerSymbol)

--- a/broker/patron_request/api/api-handler.go
+++ b/broker/patron_request/api/api-handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -560,7 +561,7 @@ func toApiPatronRequest(request pr_db.PatronRequest, illRequest iso18626.Request
 		Patron:             toString(request.Patron),
 		RequesterSymbol:    toString(request.RequesterSymbol),
 		SupplierSymbol:     toString(request.SupplierSymbol),
-		IllRequest:         utils.Must(common.StructToMap(illRequest)),
+		IllRequest:         illRequest,
 		RequesterRequestId: toString(request.RequesterReqID),
 		NeedsAttention:     request.NeedsAttention,
 		LastAction:         toString(request.LastAction),
@@ -605,7 +606,7 @@ func (a *PatronRequestApiHandler) parseAndValidateIllRequest(
 		}
 		requesterReqId = hrid
 	}
-	illRequest, err := parseAndValidateIllRequestPayload(
+	illRequest, err := prepareAndValidateIllRequest(
 		request.IllRequest,
 		reqSymbolType,
 		reqSymbolValue,
@@ -644,25 +645,17 @@ func parseAgencySymbol(symbol string) (string, string, error) {
 	return scheme, value, nil
 }
 
-func parseAndValidateIllRequestPayload(
-	rawIllRequest map[string]interface{},
+func prepareAndValidateIllRequest(
+	rawIllRequest iso18626.Request,
 	reqSymbolType string,
 	reqSymbolValue string,
 	requesterReqId string,
 	creationTime time.Time,
 ) (iso18626.Request, error) {
-	var illRequest iso18626.Request
-	if rawIllRequest == nil {
+	if reflect.ValueOf(rawIllRequest).IsZero() {
 		return iso18626.Request{}, fmt.Errorf("%w: missing required illRequest payload", errInvalidPatronRequest)
 	}
-	illRequestBytes, err := json.Marshal(rawIllRequest)
-	if err != nil {
-		return iso18626.Request{}, fmt.Errorf("%w: illRequest: %w", errInvalidPatronRequest, err)
-	}
-	err = json.Unmarshal(illRequestBytes, &illRequest)
-	if err != nil {
-		return iso18626.Request{}, fmt.Errorf("%w: illRequest: %w", errInvalidPatronRequest, err)
-	}
+	illRequest := rawIllRequest
 	suppSymbolType, suppSymbolValue, err := parseAgencySymbol(brokerSymbol)
 	if err != nil {
 		return iso18626.Request{}, fmt.Errorf("invalid BROKER_SYMBOL %q: %w", brokerSymbol, err)

--- a/broker/patron_request/api/api-handler_test.go
+++ b/broker/patron_request/api/api-handler_test.go
@@ -512,7 +512,3 @@ type MockEventBus struct {
 	mock.Mock
 	events.EventBus
 }
-
-func ptr(value string) *string {
-	return &value
-}

--- a/broker/patron_request/api/api-handler_test.go
+++ b/broker/patron_request/api/api-handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/indexdata/crosslink/broker/patron_request/proapi"
 	prservice "github.com/indexdata/crosslink/broker/patron_request/service"
 	"github.com/indexdata/crosslink/broker/test/mocks"
+	"github.com/indexdata/crosslink/iso18626"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,17 @@ var symbol = "ISIL:REQ"
 var lendingString = string(prservice.SideLending)
 var proapiBorrowingSide = proapi.Side(prservice.SideBorrowing)
 var proapiLendingSide = proapi.Side(prservice.SideLending)
+
+func validIllRequest() iso18626.Request {
+	return iso18626.Request{
+		BibliographicInfo: iso18626.BibliographicInfo{
+			Title: "Test title",
+		},
+		ServiceInfo: &iso18626.ServiceInfo{
+			ServiceType: iso18626.TypeServiceTypeCopy,
+		},
+	}
+}
 
 func TestGetId(t *testing.T) {
 	assert.True(t, getId("") != "")
@@ -117,14 +129,7 @@ func TestPostPatronRequests(t *testing.T) {
 	toCreate := proapi.CreatePatronRequest{
 		Id:              &id,
 		RequesterSymbol: &symbol,
-		IllRequest: map[string]interface{}{
-			"bibliographicInfo": map[string]interface{}{
-				"title": "test",
-			},
-			"serviceInfo": map[string]interface{}{
-				"serviceType": "Copy",
-			},
-		},
+		IllRequest:      validIllRequest(),
 	}
 	jsonBytes, err := json.Marshal(toCreate)
 	assert.NoError(t, err, "failed to marshal patron request")
@@ -163,15 +168,11 @@ func TestPostPatronRequestsInvalidJson(t *testing.T) {
 
 func TestPostPatronRequestsInvalidIllRequestShape(t *testing.T) {
 	handler := NewPrApiHandler(new(PrRepoError), mockEventBus, mockEventRepo, common.NewTenant(""), 10)
-	toCreate := proapi.CreatePatronRequest{
-		Id:              ptr("1"),
-		RequesterSymbol: &symbol,
-		IllRequest: map[string]interface{}{
-			"header": "invalid",
-		},
-	}
-	jsonBytes, err := json.Marshal(toCreate)
-	assert.NoError(t, err, "failed to marshal patron request")
+	jsonBytes := []byte(`{
+		"id":"1",
+		"requesterSymbol":"` + symbol + `",
+		"illRequest":{"header":"invalid"}
+	}`)
 	req, err := http.NewRequest("POST", "/", bytes.NewBuffer(jsonBytes))
 	assert.NoError(t, err, "failed to create request")
 	rr := httptest.NewRecorder()
@@ -402,14 +403,7 @@ func TestParseAndValidateIllRequestAndBuildDbPatronRequest(t *testing.T) {
 	reqWithID := &proapi.CreatePatronRequest{
 		Id:              &id,
 		RequesterSymbol: &symbol,
-		IllRequest: map[string]interface{}{
-			"serviceInfo": map[string]interface{}{
-				"serviceType": "Copy",
-			},
-			"bibliographicInfo": map[string]interface{}{
-				"title": "Test title",
-			},
-		},
+		IllRequest:      validIllRequest(),
 	}
 
 	illRequest, requesterReqID, err := handler.parseAndValidateIllRequest(ctx, reqWithID, creationTime)
@@ -449,14 +443,7 @@ func TestParseAndValidateIllRequestInvalidBrokerSymbol(t *testing.T) {
 
 	_, _, err := handler.parseAndValidateIllRequest(ctx, &proapi.CreatePatronRequest{
 		RequesterSymbol: &symbol,
-		IllRequest: map[string]interface{}{
-			"serviceInfo": map[string]interface{}{
-				"serviceType": "Copy",
-			},
-			"bibliographicInfo": map[string]interface{}{
-				"title": "Test title",
-			},
-		},
+		IllRequest:      validIllRequest(),
 	}, time.Now())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid BROKER_SYMBOL")

--- a/broker/test/api/api-handler_test.go
+++ b/broker/test/api/api-handler_test.go
@@ -32,6 +32,7 @@ import (
 	apptest "github.com/indexdata/crosslink/broker/test/apputils"
 	mocks "github.com/indexdata/crosslink/broker/test/mocks"
 	test "github.com/indexdata/crosslink/broker/test/utils"
+	"github.com/indexdata/crosslink/directory"
 	"github.com/indexdata/go-utils/utils"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -462,10 +463,10 @@ func TestPeersCRUD(t *testing.T) {
 		"X-Okapi-Tenant": "diku",
 		"X-Okapi-Url":    "http://localhost:1234",
 	}
-	custom := map[string]interface{}{
-		"name":  "v1",
-		"email": "v2",
-		"lost":  "value",
+	email := "v2"
+	custom := directory.Entry{
+		Name:  "v1",
+		Email: &email,
 	}
 	// Create peer
 	loanCount := int32(5)
@@ -503,9 +504,11 @@ func TestPeersCRUD(t *testing.T) {
 	assert.Equal(t, "https://url.com", respPeers.Items[0].Url)
 	assert.Equal(t, oapi.Opaque, respPeers.Items[0].BrokerMode)
 	assert.Equal(t, "Unknown", respPeers.Items[0].Vendor)
-	assert.Equal(t, "v1", (*respPeers.Items[0].CustomData)["name"])
-	assert.Equal(t, "v2", (*respPeers.Items[0].CustomData)["email"])
-	assert.Nil(t, (*respPeers.Items[0].CustomData)["lost"])
+	assert.NotNil(t, respPeers.Items[0].CustomData)
+	assert.Equal(t, "v1", respPeers.Items[0].CustomData.Name)
+	if assert.NotNil(t, respPeers.Items[0].CustomData.Email) {
+		assert.Equal(t, "v2", *respPeers.Items[0].CustomData.Email)
+	}
 	assert.Equal(t, "http://localhost:1234", (*respPeers.Items[0].HttpHeaders)["X-Okapi-Url"])
 	assert.Equal(t, int32(5), *respPeers.Items[0].LoansCount)
 	assert.Equal(t, int32(10), *respPeers.Items[0].BorrowsCount)
@@ -576,8 +579,10 @@ func TestPeersCRUD(t *testing.T) {
 	assert.GreaterOrEqual(t, len(respPeers.Items), 1)
 	assert.Equal(t, toCreate.Id, respPeers.Items[0].Id)
 	assert.NotNil(t, respPeers.Items[0].CustomData)
-	assert.Equal(t, "v1", (*respPeers.Items[0].CustomData)["name"])
-	assert.Equal(t, "v2", (*respPeers.Items[0].CustomData)["email"])
+	assert.Equal(t, "v1", respPeers.Items[0].CustomData.Name)
+	if assert.NotNil(t, respPeers.Items[0].CustomData.Email) {
+		assert.Equal(t, "v2", *respPeers.Items[0].CustomData.Email)
+	}
 	assert.Equal(t, "http://localhost:1234", (*respPeers.Items[0].HttpHeaders)["X-Okapi-Url"])
 
 	// Delete peer

--- a/broker/test/patron_request/api/api-handler_test.go
+++ b/broker/test/patron_request/api/api-handler_test.go
@@ -120,7 +120,7 @@ func TestCrud(t *testing.T) {
 		Id:              &id,
 		RequesterSymbol: &requesterSymbol,
 		Patron:          &patron,
-		IllRequest:      utils.Must(common.StructToMap(request)),
+		IllRequest:      request,
 	}
 	newPrBytes, err := json.Marshal(newPr)
 	assert.NoError(t, err, "failed to marshal patron request")
@@ -287,17 +287,9 @@ func TestCrud(t *testing.T) {
 	//httpRequest(t, "DELETE", thisPrPath, []byte{}, 404)
 }
 
-func assertPatronRequestIllRequest(t *testing.T, payload map[string]interface{}, assertFn func(iso18626.Request)) {
+func assertPatronRequestIllRequest(t *testing.T, payload iso18626.Request, assertFn func(iso18626.Request)) {
 	t.Helper()
-
-	data, err := json.Marshal(payload)
-	assert.NoError(t, err)
-
-	var request iso18626.Request
-	err = json.Unmarshal(data, &request)
-	assert.NoError(t, err)
-
-	assertFn(request)
+	assertFn(payload)
 }
 
 func TestActionsToCompleteState(t *testing.T) {
@@ -328,7 +320,7 @@ func TestActionsToCompleteState(t *testing.T) {
 	newPr := proapi.CreatePatronRequest{
 		RequesterSymbol: &requesterSymbol,
 		Patron:          &patron,
-		IllRequest:      utils.Must(common.StructToMap(request)),
+		IllRequest:      request,
 	}
 	newPrBytes, err := json.Marshal(newPr)
 	assert.NoError(t, err, "failed to marshal patron request")
@@ -537,12 +529,12 @@ func TestPostPatronRequestRejectsInvalidIllRequest(t *testing.T) {
 
 	newPr := proapi.CreatePatronRequest{
 		RequesterSymbol: &requesterSymbol,
-		IllRequest: map[string]interface{}{
-			"bibliographicInfo": map[string]interface{}{
-				"title": "Invalid request",
+		IllRequest: iso18626.Request{
+			BibliographicInfo: iso18626.BibliographicInfo{
+				Title: "Invalid request",
 			},
-			"serviceInfo": map[string]interface{}{
-				"serviceType": "Broken",
+			ServiceInfo: &iso18626.ServiceInfo{
+				ServiceType: iso18626.TypeServiceType("Broken"),
 			},
 		},
 	}


### PR DESCRIPTION
This avoids the  StructToMap for iso18626.Request, eventData, resultData, illTransactionData and Peer.customData