### PR TITLE
Fix/DRY IsBrokerRequest

### DIFF
--- a/broker/api/common.go
+++ b/broker/api/common.go
@@ -7,11 +7,8 @@ import (
 	"strings"
 
 	"github.com/indexdata/crosslink/broker/oapi"
+	"github.com/indexdata/crosslink/broker/tenant"
 )
-
-func IsBrokerRequest(r *http.Request) bool {
-	return strings.Contains(r.RequestURI, "/broker/")
-}
 
 func WithBrokerPrefix(r *http.Request, path string) string {
 	if path == "" {
@@ -20,7 +17,7 @@ func WithBrokerPrefix(r *http.Request, path string) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if IsBrokerRequest(r) {
+	if tenant.IsBrokerRequest(r) {
 		if path == "/" {
 			return "/broker/"
 		}

--- a/broker/tenant/tenant.go
+++ b/broker/tenant/tenant.go
@@ -16,6 +16,10 @@ type TenantContext struct {
 	tenantSymbolMap        string
 }
 
+func IsBrokerRequest(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, "/broker/")
+}
+
 func NewContext() *TenantContext {
 	return &TenantContext{}
 }
@@ -60,7 +64,7 @@ func (s *TenantContext) WithRequest(ctx common.ExtendedContext, r *http.Request,
 		tenantContext: s,
 		tenant:        r.Header.Get("X-Okapi-Tenant"),
 		ctx:           ctx,
-		okapiEndpoint: strings.HasPrefix(r.URL.Path, "/broker/"),
+		okapiEndpoint: IsBrokerRequest(r),
 		symbol:        pSymbol,
 	}
 	return t


### PR DESCRIPTION
One place for check of /broker in path. Avoid false positive.. Eg a URI parameter of "/broker/" would be considered a broker request.