### PR TITLE
Case-insensitive CQL indexes only

### DIFF
--- a/broker/migrations/030_lower_pr_symbol_indexes.down.sql
+++ b/broker/migrations/030_lower_pr_symbol_indexes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_pr_requester_symbol_lower;
+DROP INDEX IF EXISTS idx_pr_supplier_symbol_lower;
+DROP INDEX IF EXISTS idx_pr_requester_req_id_lower;

--- a/broker/migrations/030_lower_pr_symbol_indexes.up.sql
+++ b/broker/migrations/030_lower_pr_symbol_indexes.up.sql
@@ -1,3 +1,3 @@
-CREATE INDEX idx_pr_requester_symbol_lower ON patron_request (lower(requester_symbol) varchar_pattern_ops);
-CREATE INDEX idx_pr_supplier_symbol_lower ON patron_request (lower(supplier_symbol) varchar_pattern_ops);
-CREATE INDEX idx_pr_requester_req_id_lower ON patron_request (lower(requester_req_id) varchar_pattern_ops);
+CREATE INDEX idx_pr_requester_symbol_lower ON patron_request (lower(requester_symbol) text_pattern_ops);
+CREATE INDEX idx_pr_supplier_symbol_lower ON patron_request (lower(supplier_symbol) text_pattern_ops);
+CREATE INDEX idx_pr_requester_req_id_lower ON patron_request (lower(requester_req_id) text_pattern_ops);

--- a/broker/migrations/030_lower_pr_symbol_indexes.up.sql
+++ b/broker/migrations/030_lower_pr_symbol_indexes.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_pr_requester_symbol_lower ON patron_request (lower(requester_symbol) varchar_pattern_ops);
+CREATE INDEX idx_pr_supplier_symbol_lower ON patron_request (lower(supplier_symbol) varchar_pattern_ops);
+CREATE INDEX idx_pr_requester_req_id_lower ON patron_request (lower(requester_req_id) varchar_pattern_ops);

--- a/broker/patron_request/api/api-handler.go
+++ b/broker/patron_request/api/api-handler.go
@@ -155,7 +155,7 @@ func (a *PatronRequestApiHandler) GetPatronRequests(w http.ResponseWriter, r *ht
 		}
 	}
 	if params.RequesterReqId != nil {
-		_, err = qb.And().Search("requester_req_id").Term(*params.RequesterReqId).Build()
+		_, err = qb.And().Search("requester_req_id_exact").Term(*params.RequesterReqId).Build()
 		if err != nil {
 			api.AddBadRequestError(ctx, w, err)
 			return
@@ -195,22 +195,22 @@ func addOwnerRestriction(queryBuilder *cqlbuilder.QueryBuilder, symbol string, s
 	case prservice.SideLending:
 		_, err = queryBuilder.And().
 			Search("side").Term(string(prservice.SideLending)).
-			And().Search("supplier_symbol").Term(symbol).
+			And().Search("supplier_symbol_exact").Term(symbol).
 			Build()
 	case prservice.SideBorrowing:
 		_, err = queryBuilder.And().
 			Search("side").Term(string(prservice.SideBorrowing)).
-			And().Search("requester_symbol").Term(symbol).
+			And().Search("requester_symbol_exact").Term(symbol).
 			Build()
 	default:
 		_, err = queryBuilder.And().
 			BeginClause().
 			Search("side").Term(string(prservice.SideLending)).
-			And().Search("supplier_symbol").Term(symbol).
+			And().Search("supplier_symbol_exact").Term(symbol).
 			EndClause().
 			Or().
 			BeginClause().Search("side").Term(string(prservice.SideBorrowing)).
-			And().Search("requester_symbol").Term(symbol).
+			And().Search("requester_symbol_exact").Term(symbol).
 			EndClause().
 			Build()
 	}

--- a/broker/patron_request/api/api-handler_test.go
+++ b/broker/patron_request/api/api-handler_test.go
@@ -176,9 +176,9 @@ func TestGetPatronRequestsWithRequesterReqId(t *testing.T) {
 	handler.GetPatronRequests(rr, req, params)
 	assert.Equal(t, http.StatusOK, rr.Code)
 	if assert.NotNil(t, repo.cql) {
-		assert.Contains(t, *repo.cql, "requester_req_id = req-123")
+		assert.Contains(t, *repo.cql, "requester_req_id_exact = req-123")
 		assert.Contains(t, *repo.cql, "side = lending")
-		assert.Contains(t, *repo.cql, "supplier_symbol = ISIL:REQ")
+		assert.Contains(t, *repo.cql, "supplier_symbol_exact = ISIL:REQ")
 	}
 }
 

--- a/broker/patron_request/db/prcql.go
+++ b/broker/patron_request/db/prcql.go
@@ -34,14 +34,23 @@ func handlePatronRequestsQuery(cqlString string, noBaseArgs int) (pgcql.Query, e
 	f = pgcql.NewFieldString().WithExact()
 	def.AddField("side", f)
 
-	f = pgcql.NewFieldString().WithLikeOps()
+	f = pgcql.NewFieldString().WithLikeOps().WithLower()
 	def.AddField("requester_symbol", f)
 
-	f = pgcql.NewFieldString().WithLikeOps()
+	f = pgcql.NewFieldString().WithExact().WithColumn("requester_symbol")
+	def.AddField("requester_symbol_exact", f)
+
+	f = pgcql.NewFieldString().WithLikeOps().WithLower()
 	def.AddField("supplier_symbol", f)
 
-	f = pgcql.NewFieldString().WithLikeOps()
+	f = pgcql.NewFieldString().WithExact().WithColumn("supplier_symbol")
+	def.AddField("supplier_symbol_exact", f)
+
+	f = pgcql.NewFieldString().WithLikeOps().WithLower()
 	def.AddField("requester_req_id", f)
+
+	f = pgcql.NewFieldString().WithExact().WithColumn("requester_req_id")
+	def.AddField("requester_req_id_exact", f)
 
 	fb := pgcql.NewFieldBool()
 	def.AddField("needs_attention", fb)

--- a/broker/test/patron_request/api/api-handler_test.go
+++ b/broker/test/patron_request/api/api-handler_test.go
@@ -116,7 +116,7 @@ func TestCrud(t *testing.T) {
 			},
 		},
 	}
-	id := uuid.NewString()
+	id := "REQ-" + strings.ToUpper(uuid.NewString())
 	newPr := proapi.CreatePatronRequest{
 		Id:              &id,
 		RequesterSymbol: &requesterSymbol,
@@ -192,6 +192,26 @@ func TestCrud(t *testing.T) {
 		assert.Equal(t, "Typed request round trip", r.BibliographicInfo.Title)
 		assert.Equal(t, *newPr.Id, r.Header.RequestingAgencyRequestId)
 	})
+
+	// GET list symbol/requester_req_id params are translated to exact CQL fields.
+	respBytes = httpRequest(t, "GET", basePath+"?side=borrowing&symbol="+url.QueryEscape(strings.ToLower(*foundPr.RequesterSymbol)), []byte{}, 200)
+	err = json.Unmarshal(respBytes, &foundPrs)
+	assert.NoError(t, err, "failed to unmarshal patron request")
+	assert.Equal(t, int64(0), foundPrs.About.Count)
+	assert.Len(t, foundPrs.Items, 0)
+
+	respBytes = httpRequest(t, "GET", basePath+"?requester_req_id="+url.QueryEscape(*newPr.Id), []byte{}, 200)
+	err = json.Unmarshal(respBytes, &foundPrs)
+	assert.NoError(t, err, "failed to unmarshal patron request")
+	assert.Equal(t, int64(1), foundPrs.About.Count)
+	assert.Len(t, foundPrs.Items, 1)
+	assert.Equal(t, *newPr.Id, foundPrs.Items[0].Id)
+
+	respBytes = httpRequest(t, "GET", basePath+"?requester_req_id="+url.QueryEscape(strings.ToLower(*newPr.Id)), []byte{}, 200)
+	err = json.Unmarshal(respBytes, &foundPrs)
+	assert.NoError(t, err, "failed to unmarshal patron request")
+	assert.Equal(t, int64(0), foundPrs.About.Count)
+	assert.Len(t, foundPrs.Items, 0)
 
 	// GET list with offset in
 	respBytes = httpRequest(t, "GET", basePath+queryParams+"&offset=100000", []byte{}, 200)

--- a/broker/test/patron_request/db/prrepo_test.go
+++ b/broker/test/patron_request/db/prrepo_test.go
@@ -323,6 +323,10 @@ func TestListPatronRequests(t *testing.T) {
 				String: "ISIL:REQ",
 				Valid:  true,
 			},
+			SupplierSymbol: pgtype.Text{
+				String: "ISIL:SUP",
+				Valid:  true,
+			},
 			State:    prservice.BorrowerStateValidated,
 			Language: "english",
 			RequesterReqID: pgtype.Text{
@@ -357,6 +361,33 @@ func TestListPatronRequests(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, list, 1)
+	assert.Equal(t, int64(2), fullCount)
+
+	cql = "requester_symbol = isil:req"
+	list, fullCount, err = prRepo.ListPatronRequests(appCtx, pr_db.ListPatronRequestsParams{
+		Limit:  10,
+		Offset: 0,
+	}, &cql)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, int64(2), fullCount)
+
+	cql = "supplier_symbol = isil:sup"
+	list, fullCount, err = prRepo.ListPatronRequests(appCtx, pr_db.ListPatronRequestsParams{
+		Limit:  10,
+		Offset: 0,
+	}, &cql)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, int64(2), fullCount)
+
+	cql = "requester_req_id = req-123"
+	list, fullCount, err = prRepo.ListPatronRequests(appCtx, pr_db.ListPatronRequestsParams{
+		Limit:  10,
+		Offset: 0,
+	}, &cql)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
 	assert.Equal(t, int64(2), fullCount)
 
 	// not found


### PR DESCRIPTION
Adds new lower-case indexes used only for CQL fields, API and static SQL remains as-is