### PR TITLE
Add ILLiad shim

### DIFF
--- a/broker/shim/shim.go
+++ b/broker/shim/shim.go
@@ -51,6 +51,8 @@ func GetShim(vendor string) Iso18626Shim {
 	switch vendor {
 	case string(directory.Alma):
 		shim = new(Iso18626AlmaShim)
+	case string(directory.ILLiad):
+		shim = new(Iso18626ILLiadShim)
 	case string(directory.ReShare):
 		shim = new(Iso18626ReShareShim)
 	default:
@@ -87,6 +89,10 @@ type Iso18626AlmaShim struct {
 }
 
 func (i *Iso18626AlmaShim) ApplyToIncomingRequest(message *iso18626.ISO18626Message, requester *ill_db.Peer, supplier *ill_db.LocatedSupplier) *iso18626.ISO18626Message {
+	return applyToIncomingRequest(message, supplier)
+}
+
+func applyToIncomingRequest(message *iso18626.ISO18626Message, supplier *ill_db.LocatedSupplier) *iso18626.ISO18626Message {
 	if message == nil {
 		return message
 	}
@@ -94,7 +100,7 @@ func (i *Iso18626AlmaShim) ApplyToIncomingRequest(message *iso18626.ISO18626Mess
 	if message.RequestingAgencyMessage != nil {
 		copyRam := *message.RequestingAgencyMessage
 		copyMessage.RequestingAgencyMessage = &copyRam
-		conditionNote := i.fixRequesterConditionNote(copyMessage.RequestingAgencyMessage)
+		conditionNote := fixRequesterConditionNote(copyMessage.RequestingAgencyMessage)
 		if conditionNote == RESHARE_LOAN_CONDITION_REJECT && supplier != nil && supplier.SupplierSymbol != "" {
 			// condition reject is handled as a non-terminal Cancel addressed to the supplier
 			// regular Cancel is always terminal (addressed to broker)
@@ -107,7 +113,7 @@ func (i *Iso18626AlmaShim) ApplyToIncomingRequest(message *iso18626.ISO18626Mess
 	if message.SupplyingAgencyMessage != nil {
 		copySam := *message.SupplyingAgencyMessage
 		copyMessage.SupplyingAgencyMessage = &copySam
-		i.unifyItem(copyMessage.SupplyingAgencyMessage)
+		packItemIdIntoItemsNote(copyMessage.SupplyingAgencyMessage)
 	}
 	return &copyMessage
 }
@@ -118,48 +124,88 @@ func (i *Iso18626AlmaShim) ApplyToOutgoingRequest(message *iso18626.ISO18626Mess
 			suppMsg := message.SupplyingAgencyMessage
 			i.fixStatus(suppMsg)
 			i.fixReasonForMessage(suppMsg)
-			i.fixLoanCondition(suppMsg)
+			fixLoanCondition(suppMsg)
 			i.transferOfferedCostsToDeliveryCosts(suppMsg)
-			i.stripReShareSuppMsgSeqNote(suppMsg)
-			i.humanizeReShareSupplierConditionNote(suppMsg)
+			stripReShareSuppMsgSeqNote(suppMsg)
+			humanizeReShareSupplierConditionNote(suppMsg)
 			i.prependURLToSuppMsgNote(suppMsg)
 			i.prependLoanConditionOrCostToNote(suppMsg)
 			if suppMsg.StatusInfo.Status == iso18626.TypeStatusLoaned {
 				i.appendReturnAddressToSuppMsgNote(suppMsg)
 			}
 			i.appendUnfilledStatusAndReasonUnfilled(suppMsg)
-			i.setItemId(suppMsg)
+			setItemIdFromItemsNote(suppMsg)
 		}
 		if message.Request != nil {
 			request := message.Request
-			i.fixServiceLevel(request)
-			i.fixBibItemIds(request)
-			i.fixBibRecIds(request)
-			i.fixPublicationType(request)
-			i.stripReShareReqSeqNote(request)
+			fixServiceLevel(request)
+			fixBibItemIds(request)
+			fixBibRecIds(request)
+			fixPublicationType(request)
+			stripReShareReqSeqNote(request)
 			i.appendMaxCostToReqNote(request)
 			i.appendDeliveryAddressToReqNote(request)
 			i.appendReturnAddressToReqNote(request)
 		}
 		if message.RequestingAgencyMessage != nil {
 			reqMsg := message.RequestingAgencyMessage
-			i.stripReShareReqMsgSeqNote(reqMsg)
-			i.humanizeReShareRequesterNote(reqMsg)
+			stripReShareReqMsgSeqNote(reqMsg)
+			humanizeReShareRequesterNote(reqMsg)
 		}
 	}
 	return xml.Marshal(message)
 }
 
-func (i *Iso18626AlmaShim) stripReShareSuppMsgSeqNote(suppMsg *iso18626.SupplyingAgencyMessage) {
+type Iso18626ILLiadShim struct {
+	Iso18626DefaultShim
+}
+
+func (i *Iso18626ILLiadShim) ApplyToIncomingRequest(message *iso18626.ISO18626Message, requester *ill_db.Peer, supplier *ill_db.LocatedSupplier) *iso18626.ISO18626Message {
+	return applyToIncomingRequest(message, supplier)
+}
+
+func (i *Iso18626ILLiadShim) ApplyToOutgoingRequest(message *iso18626.ISO18626Message) ([]byte, error) {
+	if message != nil {
+		if message.SupplyingAgencyMessage != nil {
+			suppMsg := message.SupplyingAgencyMessage
+			fixLoanCondition(suppMsg)
+			stripReShareSuppMsgSeqNote(suppMsg)
+			humanizeReShareSupplierConditionNote(suppMsg)
+			setItemIdFromItemsNote(suppMsg)
+		}
+		if message.Request != nil {
+			request := message.Request
+			fixServiceLevel(request)
+			fixBibItemIds(request)
+			fixBibRecIds(request)
+			fixPublicationType(request)
+			stripReShareReqSeqNote(request)
+		}
+		if message.RequestingAgencyMessage != nil {
+			reqMsg := message.RequestingAgencyMessage
+			stripReShareReqMsgSeqNote(reqMsg)
+			humanizeReShareRequesterNote(reqMsg)
+		}
+	}
+	return xml.Marshal(message)
+}
+
+func stripReShareSuppMsgSeqNote(suppMsg *iso18626.SupplyingAgencyMessage) {
+	if suppMsg == nil {
+		return
+	}
 	suppMsg.MessageInfo.Note = rsNoteRegexp.ReplaceAllString(suppMsg.MessageInfo.Note, "")
 }
 
-func (i *Iso18626AlmaShim) stripReShareReqMsgSeqNote(reqMsg *iso18626.RequestingAgencyMessage) {
+func stripReShareReqMsgSeqNote(reqMsg *iso18626.RequestingAgencyMessage) {
+	if reqMsg == nil {
+		return
+	}
 	reqMsg.Note = rsNoteRegexp.ReplaceAllString(reqMsg.Note, "")
 }
 
-func (i *Iso18626AlmaShim) stripReShareReqSeqNote(request *iso18626.Request) {
-	if request.ServiceInfo == nil {
+func stripReShareReqSeqNote(request *iso18626.Request) {
+	if request == nil || request.ServiceInfo == nil {
 		return
 	}
 	request.ServiceInfo.Note = rsNoteRegexp.ReplaceAllString(request.ServiceInfo.Note, "")
@@ -220,7 +266,10 @@ func (i *Iso18626AlmaShim) appendUnfilledStatusAndReasonUnfilled(suppMsg *iso186
 	}
 }
 
-func (i *Iso18626AlmaShim) setItemId(sam *iso18626.SupplyingAgencyMessage) {
+func setItemIdFromItemsNote(sam *iso18626.SupplyingAgencyMessage) {
+	if sam == nil || sam.DeliveryInfo == nil {
+		return
+	}
 	result, startIdx, endIdx := common.UnpackItemsNote(sam.MessageInfo.Note)
 	if result == nil {
 		return
@@ -320,7 +369,10 @@ func (*Iso18626AlmaShim) fixReasonForMessage(suppMsg *iso18626.SupplyingAgencyMe
 	}
 }
 
-func (i *Iso18626AlmaShim) fixLoanCondition(request *iso18626.SupplyingAgencyMessage) {
+func fixLoanCondition(request *iso18626.SupplyingAgencyMessage) {
+	if request == nil {
+		return
+	}
 	if request.DeliveryInfo == nil || request.DeliveryInfo.LoanCondition == nil {
 		return
 	}
@@ -395,8 +447,8 @@ func (i *Iso18626AlmaShim) appendReturnAddressToReqNote(request *iso18626.Reques
 	}
 }
 
-func (i *Iso18626AlmaShim) fixServiceLevel(request *iso18626.Request) {
-	if request.ServiceInfo == nil || request.ServiceInfo.ServiceLevel == nil {
+func fixServiceLevel(request *iso18626.Request) {
+	if request == nil || request.ServiceInfo == nil || request.ServiceInfo.ServiceLevel == nil {
 		return
 	}
 	serviceLevel, ok := iso18626.ServiceLevelFromStringCI(request.ServiceInfo.ServiceLevel.Text)
@@ -406,8 +458,8 @@ func (i *Iso18626AlmaShim) fixServiceLevel(request *iso18626.Request) {
 	request.ServiceInfo.ServiceLevel.Text = string(serviceLevel)
 }
 
-func (i *Iso18626AlmaShim) fixPublicationType(request *iso18626.Request) {
-	if request.PublicationInfo == nil || request.PublicationInfo.PublicationType == nil {
+func fixPublicationType(request *iso18626.Request) {
+	if request == nil || request.PublicationInfo == nil || request.PublicationInfo.PublicationType == nil {
 		return
 	}
 	pubType, ok := iso18626.PublicationTypeFromStringCI(request.PublicationInfo.PublicationType.Text)
@@ -416,7 +468,10 @@ func (i *Iso18626AlmaShim) fixPublicationType(request *iso18626.Request) {
 	}
 }
 
-func (i *Iso18626AlmaShim) fixBibItemIds(request *iso18626.Request) {
+func fixBibItemIds(request *iso18626.Request) {
+	if request == nil {
+		return
+	}
 	var bibItemIds []iso18626.BibliographicItemId
 	for _, bibItemId := range request.BibliographicInfo.BibliographicItemId {
 		val, err := iso18626.BibliographicItemIdCodeFromString(strings.ToUpper(bibItemId.BibliographicItemIdentifierCode.Text))
@@ -432,7 +487,10 @@ func (i *Iso18626AlmaShim) fixBibItemIds(request *iso18626.Request) {
 	request.BibliographicInfo.BibliographicItemId = bibItemIds
 }
 
-func (i *Iso18626AlmaShim) fixBibRecIds(request *iso18626.Request) {
+func fixBibRecIds(request *iso18626.Request) {
+	if request == nil {
+		return
+	}
 	var bibRecIds []iso18626.BibliographicRecordId
 	for _, bibRecId := range request.BibliographicInfo.BibliographicRecordId {
 		val, err := iso18626.BibliographicRecordIdCodeFromString(strings.ToUpper(bibRecId.BibliographicRecordIdentifierCode.Text))
@@ -517,7 +575,10 @@ func MarshalAddress(sb *strings.Builder, addr *iso18626.PhysicalAddress) {
 	}
 }
 
-func (i *Iso18626AlmaShim) humanizeReShareRequesterNote(ram *iso18626.RequestingAgencyMessage) {
+func humanizeReShareRequesterNote(ram *iso18626.RequestingAgencyMessage) {
+	if ram == nil {
+		return
+	}
 	if strings.Contains(ram.Note, RESHARE_LOAN_CONDITION_AGREE) {
 		note := strings.ReplaceAll(ram.Note, RESHARE_LOAN_CONDITION_AGREE, "")
 		note = strings.TrimSpace(note)
@@ -525,7 +586,10 @@ func (i *Iso18626AlmaShim) humanizeReShareRequesterNote(ram *iso18626.Requesting
 	}
 }
 
-func (i *Iso18626AlmaShim) humanizeReShareSupplierConditionNote(supplyingAgencyMessage *iso18626.SupplyingAgencyMessage) {
+func humanizeReShareSupplierConditionNote(supplyingAgencyMessage *iso18626.SupplyingAgencyMessage) {
+	if supplyingAgencyMessage == nil {
+		return
+	}
 	if strings.TrimSpace(supplyingAgencyMessage.MessageInfo.Note) == RESHARE_SUPPLIER_AWAITING_CONDITION {
 		supplyingAgencyMessage.MessageInfo.Note = ALMA_SUPPLIER_AWAITING_CONDITION
 		return
@@ -542,7 +606,10 @@ func (i *Iso18626AlmaShim) humanizeReShareSupplierConditionNote(supplyingAgencyM
 	}
 }
 
-func (i *Iso18626AlmaShim) fixRequesterConditionNote(requestingAgencyMessage *iso18626.RequestingAgencyMessage) string {
+func fixRequesterConditionNote(requestingAgencyMessage *iso18626.RequestingAgencyMessage) string {
+	if requestingAgencyMessage == nil {
+		return ""
+	}
 	if requestingAgencyMessage.Action == iso18626.TypeActionNotification {
 		note := rsNoteRegexp.ReplaceAllString(requestingAgencyMessage.Note, "") //this is only needed to test human-notes from ReShare
 		note = edgeNonWord.ReplaceAllString(note, "")
@@ -557,7 +624,10 @@ func (i *Iso18626AlmaShim) fixRequesterConditionNote(requestingAgencyMessage *is
 	return ""
 }
 
-func (i *Iso18626AlmaShim) unifyItem(sam *iso18626.SupplyingAgencyMessage) {
+func packItemIdIntoItemsNote(sam *iso18626.SupplyingAgencyMessage) {
+	if sam == nil {
+		return
+	}
 	if sam.DeliveryInfo != nil && sam.DeliveryInfo.ItemId != "" {
 		var sb strings.Builder
 		//retain original note

--- a/broker/shim/shim_test.go
+++ b/broker/shim/shim_test.go
@@ -346,6 +346,170 @@ func TestIso18626DefaultShim(t *testing.T) {
 	}
 }
 
+func TestIso18626ILLiadShimRequest(t *testing.T) {
+	msg := newReq(&iso18626.Request{
+		ServiceInfo: &iso18626.ServiceInfo{
+			Note: "#seq:0#original note",
+			ServiceLevel: &iso18626.TypeSchemeValuePair{
+				Text: "secondarymail",
+			},
+		},
+		PublicationInfo: &iso18626.PublicationInfo{
+			PublicationType: &iso18626.TypeSchemeValuePair{
+				Text: "book",
+			},
+		},
+	})
+	msg.Request.BibliographicInfo.SupplierUniqueRecordId = "12345678"
+	msg.Request.BibliographicInfo.BibliographicItemId = append(msg.Request.BibliographicInfo.BibliographicItemId,
+		iso18626.BibliographicItemId{
+			BibliographicItemIdentifierCode: iso18626.TypeSchemeValuePair{
+				Text: "isbn",
+			},
+			BibliographicItemIdentifier: "978-3-16-148410-0",
+		},
+		iso18626.BibliographicItemId{
+			BibliographicItemIdentifierCode: iso18626.TypeSchemeValuePair{
+				Text: "badcode",
+			},
+			BibliographicItemIdentifier: "val",
+		},
+	)
+	msg.Request.BibliographicInfo.BibliographicRecordId = append(msg.Request.BibliographicInfo.BibliographicRecordId,
+		iso18626.BibliographicRecordId{
+			BibliographicRecordIdentifierCode: iso18626.TypeSchemeValuePair{
+				Text: "lccn",
+			},
+			BibliographicRecordIdentifier: "2023000023",
+		},
+		iso18626.BibliographicRecordId{
+			BibliographicRecordIdentifierCode: iso18626.TypeSchemeValuePair{
+				Text: "lccnNumber",
+			},
+			BibliographicRecordIdentifier: "val",
+		},
+	)
+
+	msgBytes, err := GetShim(string(directory.ILLiad)).ApplyToOutgoingRequest(msg)
+	assert.Nil(t, err)
+
+	var resmsg iso18626.ISO18626Message
+	err = GetShim("default").ApplyToIncomingResponse(msgBytes, &resmsg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "original note", resmsg.Request.ServiceInfo.Note)
+	assert.Equal(t, "SecondaryMail", resmsg.Request.ServiceInfo.ServiceLevel.Text)
+	assert.Equal(t, "Book", resmsg.Request.PublicationInfo.PublicationType.Text)
+	assert.Len(t, resmsg.Request.BibliographicInfo.BibliographicItemId, 1)
+	assert.Equal(t, "ISBN", resmsg.Request.BibliographicInfo.BibliographicItemId[0].BibliographicItemIdentifierCode.Text)
+	assert.Len(t, resmsg.Request.BibliographicInfo.BibliographicRecordId, 2)
+	assert.Equal(t, "LCCN", resmsg.Request.BibliographicInfo.BibliographicRecordId[0].BibliographicRecordIdentifierCode.Text)
+	assert.Equal(t, "OCLC", resmsg.Request.BibliographicInfo.BibliographicRecordId[1].BibliographicRecordIdentifierCode.Text)
+}
+
+func TestIso18626ILLiadShimSupplyingAgencyMessage(t *testing.T) {
+	msg := newSAM(&iso18626.SupplyingAgencyMessage{
+		MessageInfo: iso18626.MessageInfo{
+			Note: RESHARE_SUPPLIER_AWAITING_CONDITION + "#seq:1#",
+		},
+		DeliveryInfo: &iso18626.DeliveryInfo{
+			LoanCondition: &iso18626.TypeSchemeValuePair{
+				Text: "libraryuseonly",
+			},
+		},
+	})
+
+	msgBytes, err := GetShim(string(directory.ILLiad)).ApplyToOutgoingRequest(msg)
+	assert.Nil(t, err)
+
+	var resmsg iso18626.ISO18626Message
+	err = GetShim("default").ApplyToIncomingResponse(msgBytes, &resmsg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, ALMA_SUPPLIER_AWAITING_CONDITION, resmsg.SupplyingAgencyMessage.MessageInfo.Note)
+	assert.Equal(t, string(iso18626.LoanConditionLibraryUseOnly), resmsg.SupplyingAgencyMessage.DeliveryInfo.LoanCondition.Text)
+}
+
+func TestSetItemIdFromItemsNoteILLiad(t *testing.T) {
+	msg := newSAM(&iso18626.SupplyingAgencyMessage{
+		DeliveryInfo: &iso18626.DeliveryInfo{},
+		MessageInfo: iso18626.MessageInfo{
+			Note: "send one item#seq:1#\n#MultipleItems#\n1\\|23\\\\\n#MultipleItemsEnd#",
+		},
+	})
+
+	msgBytes, err := GetShim(string(directory.ILLiad)).ApplyToOutgoingRequest(msg)
+	assert.Nil(t, err)
+
+	var resmsg iso18626.ISO18626Message
+	err = GetShim("default").ApplyToIncomingResponse(msgBytes, &resmsg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "1|23\\", resmsg.SupplyingAgencyMessage.DeliveryInfo.ItemId)
+	assert.Equal(t, "send one item", resmsg.SupplyingAgencyMessage.MessageInfo.Note)
+}
+
+func TestIso18626ILLiadShimRequestingAgencyMessage(t *testing.T) {
+	msg := newRAM(&iso18626.RequestingAgencyMessage{
+		Action: iso18626.TypeActionNotification,
+		Note:   "#seq:2#" + RESHARE_LOAN_CONDITION_AGREE + "Accept",
+	})
+
+	msgBytes, err := GetShim(string(directory.ILLiad)).ApplyToOutgoingRequest(msg)
+	assert.Nil(t, err)
+
+	var resmsg iso18626.ISO18626Message
+	err = GetShim("default").ApplyToIncomingResponse(msgBytes, &resmsg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Accept", resmsg.RequestingAgencyMessage.Note)
+}
+
+func TestIso18626ILLiadShimIncomingRequestingMessageLoanConditionReject(t *testing.T) {
+	msg := newRAM(&iso18626.RequestingAgencyMessage{
+		Header: iso18626.Header{
+			SupplyingAgencyId: iso18626.TypeAgencyId{
+				AgencyIdType: iso18626.TypeSchemeValuePair{
+					Text: "ISIL",
+				},
+				AgencyIdValue: "BROKER",
+			},
+		},
+		Action: iso18626.TypeActionNotification,
+		Note:   "--ReJeCT;",
+	})
+
+	resmsg := GetShim(string(directory.ILLiad)).ApplyToIncomingRequest(msg, nil, &ill_db.LocatedSupplier{SupplierSymbol: "ISIL:SUP1"})
+
+	assert.Equal(t, RESHARE_LOAN_CONDITION_REJECT+"--ReJeCT;", resmsg.RequestingAgencyMessage.Note)
+	assert.Equal(t, iso18626.TypeActionCancel, resmsg.RequestingAgencyMessage.Action)
+	assert.Equal(t, "SUP1", resmsg.RequestingAgencyMessage.Header.SupplyingAgencyId.AgencyIdValue)
+
+	assert.Equal(t, iso18626.TypeActionNotification, msg.RequestingAgencyMessage.Action)
+	assert.Equal(t, "BROKER", msg.RequestingAgencyMessage.Header.SupplyingAgencyId.AgencyIdValue)
+}
+
+func TestIso18626ILLiadShimIncomingSupplyingAgencyMessageUnifiesItem(t *testing.T) {
+	msg := newSAM(&iso18626.SupplyingAgencyMessage{
+		DeliveryInfo: &iso18626.DeliveryInfo{
+			ItemId: "1|23\\,1|24\\",
+		},
+		MessageInfo: iso18626.MessageInfo{
+			Note: "send multiple items",
+		},
+	})
+
+	resmsg := GetShim(string(directory.ILLiad)).ApplyToIncomingRequest(msg, nil, nil)
+
+	assert.Equal(t, "1|23\\,1|24\\", resmsg.SupplyingAgencyMessage.DeliveryInfo.ItemId)
+	assert.Equal(t, "send multiple items\n"+
+		"#MultipleItems#\n"+
+		"1\\|23\\\\\n"+
+		"1\\|24\\\\\n"+
+		"#MultipleItemsEnd#", resmsg.SupplyingAgencyMessage.MessageInfo.Note)
+	assert.Equal(t, "send multiple items", msg.SupplyingAgencyMessage.MessageInfo.Note)
+}
+
 func TestIso18626AlmaShimRequest(t *testing.T) {
 	msg := newReq(&iso18626.Request{
 		RequestingAgencyInfo: &iso18626.RequestingAgencyInfo{
@@ -1006,7 +1170,7 @@ func TestProcessItemIdMultipleItemsReShareNoNote(t *testing.T) {
 	assert.Equal(t, "", resmsg.SupplyingAgencyMessage.MessageInfo.Note)
 }
 
-func TestProcessItemIdOneItemAlma(t *testing.T) {
+func TestSetItemIdFromItemsNoteOneItemAlma(t *testing.T) {
 	shimA := new(Iso18626AlmaShim)
 
 	sam := newSAM(&iso18626.SupplyingAgencyMessage{
@@ -1035,7 +1199,7 @@ func TestProcessItemIdOneItemAlma(t *testing.T) {
 	assert.Equal(t, "send one item", resmsg.SupplyingAgencyMessage.MessageInfo.Note)
 }
 
-func TestProcessItemIdMultipleItemsAlma(t *testing.T) {
+func TestSetItemIdFromItemsNoteMultipleItemsAlma(t *testing.T) {
 	shimA := new(Iso18626AlmaShim)
 
 	sam := newSAM(&iso18626.SupplyingAgencyMessage{


### PR DESCRIPTION
Includes all ReShare-specific condition note handling and ISO normalizations Excludes Alma-specific appending to the note field, assumign ILLiad can show these fields.