### PR TITLE
Add manual patron request termination

### DIFF
--- a/broker/oapi/open-api.yaml
+++ b/broker/oapi/open-api.yaml
@@ -836,6 +836,9 @@ components:
         terminal:
           type: boolean
           description: Indicates if the state is terminal (meaning no actions or events are allowed in this state)
+        manualClose:
+          type: boolean
+          description: Indicates that this terminal state is the target for manual termination
         needsAttention:
           type: boolean
           description: Indicates that this state requires user attention (e.g. displayed as a flag in the UI)
@@ -1741,6 +1744,47 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           description: There was internal server error looking up patron request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /patron_requests/{id}/terminate:
+    post:
+      summary: Manually terminate a patron request
+      tags:
+        - patron-requests-api
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: ID of the patron request
+        - $ref: '#/components/parameters/Tenant'
+        - $ref: '#/components/parameters/Side'
+        - $ref: '#/components/parameters/Symbol'
+      responses:
+        '200':
+          description: Termination action result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionResult'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Patron request not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: There was internal server error terminating patron request
           content:
             application/json:
               schema:

--- a/broker/patron_request/api/api-handler.go
+++ b/broker/patron_request/api/api-handler.go
@@ -559,25 +559,75 @@ func (a *PatronRequestApiHandler) PostPatronRequestsIdAction(w http.ResponseWrit
 		return
 	}
 	eventAction := pr_db.PatronRequestAction(action.Action)
-	data := events.EventData{CommonEventData: events.CommonEventData{
-		Action: &eventAction,
-		User:   tenant.GetUser(),
-	}}
+	data := invokeActionData(eventAction, tenant.GetUser())
 	if action.ActionParams != nil {
 		data.CustomData = *action.ActionParams
 	}
+	a.invokeActionAndWriteResponse(w, ctx, pr.ID, fromState, data)
+}
+
+func (a *PatronRequestApiHandler) PostPatronRequestsIdTerminate(w http.ResponseWriter, r *http.Request, id string, params proapi.PostPatronRequestsIdTerminateParams) {
+	logParams := map[string]string{"method": "PostPatronRequestsIdTerminate", "id": id}
+	if params.Side != nil {
+		logParams["side"] = *params.Side
+	}
+	ctx := common.CreateExtCtxWithArgs(r.Context(), &common.LoggerArgs{Other: logParams})
+
+	tenant, err := a.tenantResolver.Resolve(ctx, r, params.Symbol)
+	if err != nil {
+		api.AddBadRequestError(ctx, w, err)
+		return
+	}
+	symbol, err := tenant.GetRequestSymbol()
+	if err != nil {
+		api.AddBadRequestError(ctx, w, err)
+		return
+	}
+	logParams["symbol"] = symbol
+	ctx = common.CreateExtCtxWithArgs(r.Context(), &common.LoggerArgs{Other: logParams})
+	pr := a.getOwnedPatronRequest(w, ctx, id, params.Side, tenant)
+	if pr == nil {
+		return
+	}
+
+	actionMapping, err := a.actionMappingService.GetActionMapping(*pr)
+	if err != nil {
+		api.AddInternalError(ctx, w, err)
+		return
+	}
+	if actionMapping.IsTerminalState(*pr) || pr.TerminalState {
+		api.AddBadRequestError(ctx, w, errors.New("patron request "+id+" is already terminal"))
+		return
+	}
+	if _, ok := actionMapping.GetManualCloseState(*pr); !ok {
+		api.AddInternalError(ctx, w, errors.New("state model does not define a manual close target for side "+string(pr.Side)))
+		return
+	}
+
+	data := invokeActionData(prservice.TerminateAction, tenant.GetUser())
+	a.invokeActionAndWriteResponse(w, ctx, pr.ID, string(pr.State), data)
+}
+
+func invokeActionData(action pr_db.PatronRequestAction, user string) events.EventData {
+	return events.EventData{CommonEventData: events.CommonEventData{
+		Action: &action,
+		User:   user,
+	}}
+}
+
+func (a *PatronRequestApiHandler) invokeActionAndWriteResponse(w http.ResponseWriter, ctx common.ExtendedContext, prID string, fromState string, data events.EventData) {
 	if a.actionTaskProcessor == nil {
 		api.AddInternalError(ctx, w, errors.New("action task processor not configured"))
 		return
 	}
-	eventId, err := a.eventBus.CreateTask(pr.ID, events.EventNameInvokeAction, data, events.EventDomainPatronRequest, nil, events.SignalConsumers)
+	eventId, err := a.eventBus.CreateTask(prID, events.EventNameInvokeAction, data, events.EventDomainPatronRequest, nil, events.SignalConsumers)
 	if err != nil {
 		api.AddInternalError(ctx, w, err)
 		return
 	}
 	completedEvent, err := a.actionTaskProcessor.ProcessInvokeActionTask(ctx, events.Event{
 		ID:              eventId,
-		PatronRequestID: pr.ID,
+		PatronRequestID: prID,
 		EventData:       data,
 	})
 	// Manual invoke-action requests are handled inline and return the completed task result.

--- a/broker/patron_request/api/api-handler_test.go
+++ b/broker/patron_request/api/api-handler_test.go
@@ -558,6 +558,54 @@ func TestPostPatronRequestsIdActionReturnsExclusiveTaskError(t *testing.T) {
 	}
 }
 
+func TestPostPatronRequestsIdActionRejectsTerminate(t *testing.T) {
+	handler := NewPrApiHandler(new(PrRepoOkapiOwner), new(MockEventBusCapture), mockEventRepo, tenant.NewResolver(), nil, 10)
+	handler.SetActionTaskProcessor(&MockActionTaskProcessor{})
+
+	reqBody := `{"action":"` + string(prservice.TerminateAction) + `"}`
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(reqBody))
+	rr := httptest.NewRecorder()
+
+	handler.PostPatronRequestsIdAction(rr, req, "3", proapi.PostPatronRequestsIdActionParams{Side: &proapiBorrowingSide})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Action terminate is not allowed")
+}
+
+func TestPostPatronRequestsIdTerminateStoresTenantUserAndActionInInvokeTask(t *testing.T) {
+	tenantResolver := tenant.NewResolver().WithTenantToSymbol("ISIL:DK-{tenant}")
+	eventBus := new(MockEventBusCapture)
+	handler := NewPrApiHandler(new(PrRepoOkapiOwner), eventBus, mockEventRepo, tenantResolver, nil, 10)
+	handler.SetActionTaskProcessor(&MockActionTaskProcessor{})
+
+	req, _ := http.NewRequest("POST", "/broker/patron_requests/3/terminate", nil)
+	req.Header.Set("X-Okapi-Tenant", "tenant1")
+	req.Header.Set("X-Okapi-User-Id", "okapi-user-1")
+	req.Header.Set("X-Okapi-Token", "header.eyJzdWIiOiJva2FwaS1zdWJqZWN0IiwidXNlcl9pZCI6Im9rYXBpLXVzZXItMSJ9.signature")
+	rr := httptest.NewRecorder()
+
+	handler.PostPatronRequestsIdTerminate(rr, req, "3", proapi.PostPatronRequestsIdTerminateParams{Side: &proapiBorrowingSide})
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, events.EventNameInvokeAction, eventBus.lastEventName)
+	assert.NotNil(t, eventBus.lastData.Action)
+	assert.Equal(t, prservice.TerminateAction, *eventBus.lastData.Action)
+	assert.Equal(t, "okapi-subject", eventBus.lastData.User)
+}
+
+func TestPostPatronRequestsIdTerminateRejectsTerminal(t *testing.T) {
+	handler := NewPrApiHandler(new(PrRepoTerminal), new(MockEventBusCapture), mockEventRepo, tenant.NewResolver(), nil, 10)
+	handler.SetActionTaskProcessor(&MockActionTaskProcessor{})
+
+	req, _ := http.NewRequest("POST", "/", nil)
+	rr := httptest.NewRecorder()
+
+	handler.PostPatronRequestsIdTerminate(rr, req, "3", proapi.PostPatronRequestsIdTerminateParams{Symbol: &symbol, Side: &proapiBorrowingSide})
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "already terminal")
+}
+
 func TestGetPatronRequestsIdEventsNoSymbol(t *testing.T) {
 	handler := NewPrApiHandler(new(PrRepoError), mockEventBus, mockEventRepo, tenant.NewResolver(), nil, 10)
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -927,9 +975,20 @@ type PrRepoOkapiOwner struct {
 	PrRepoError
 }
 
+type PrRepoTerminal struct {
+	PrRepoError
+}
+
 func (r *PrRepoOkapiOwner) GetPatronRequestById(ctx common.ExtendedContext, id string) (pr_db.PatronRequest, error) {
 	if id == "3" {
 		return pr_db.PatronRequest{ID: id, State: prservice.BorrowerStateValidated, Side: prservice.SideBorrowing, RequesterSymbol: pgtype.Text{String: "ISIL:DK-TENANT1", Valid: true}}, nil
+	}
+	return r.PrRepoError.GetPatronRequestById(ctx, id)
+}
+
+func (r *PrRepoTerminal) GetPatronRequestById(ctx common.ExtendedContext, id string) (pr_db.PatronRequest, error) {
+	if id == "3" {
+		return pr_db.PatronRequest{ID: id, State: prservice.BorrowerStateCompleted, Side: prservice.SideBorrowing, RequesterSymbol: pgtype.Text{String: symbol, Valid: true}, TerminalState: true}, nil
 	}
 	return r.PrRepoError.GetPatronRequestById(ctx, id)
 }
@@ -1073,10 +1132,12 @@ func (h *MockEventBus) CreateTask(id string, eventName events.EventName, data ev
 
 type MockEventBusCapture struct {
 	MockEventBus
-	lastData events.EventData
+	lastEventName events.EventName
+	lastData      events.EventData
 }
 
 func (h *MockEventBusCapture) CreateTask(id string, eventName events.EventName, data events.EventData, eventDomain events.EventDomain, parentId *string, target events.SignalTarget) (string, error) {
+	h.lastEventName = eventName
 	h.lastData = data
 	return uuid.NewString(), nil
 }

--- a/broker/patron_request/service/action.go
+++ b/broker/patron_request/service/action.go
@@ -96,6 +96,9 @@ func (a *PatronRequestActionService) handleInvokeAction(ctx common.ExtendedConte
 	if err != nil {
 		return logActionErrorAndReturnResult(ctx, "failed to load state model", err)
 	}
+	if action == TerminateAction {
+		return a.handleTerminateAction(ctx, actionMapping, pr, action)
+	}
 	if !actionMapping.IsActionSupported(pr, action) {
 		return logActionErrorAndReturnResult(ctx, "state "+string(pr.State)+" does not support action "+string(action), errors.New("invalid action"))
 	}
@@ -112,6 +115,42 @@ func (a *PatronRequestActionService) handleInvokeAction(ctx common.ExtendedConte
 		return a.finalizeActionExecution(ctx, event, actionMapping, action, pr, execResult)
 	default:
 		return logActionErrorAndReturnResult(ctx, "side "+string(pr.Side)+" is not supported", errors.New("invalid side"))
+	}
+}
+
+func (a *PatronRequestActionService) handleTerminateAction(ctx common.ExtendedContext, actionMapping *ActionMapping, pr pr_db.PatronRequest, action pr_db.PatronRequestAction) (events.EventStatus, *events.EventResult) {
+	if actionMapping.IsTerminalState(pr) || pr.TerminalState {
+		return logActionErrorAndReturnResult(ctx, "patron request "+pr.ID+" is already terminal", errors.New("invalid action"))
+	}
+	manualCloseState, ok := actionMapping.GetManualCloseState(pr)
+	if !ok {
+		return logActionErrorAndReturnResult(ctx, "state model does not define a manual close target for side "+string(pr.Side), errors.New("invalid state model"))
+	}
+
+	updatedPr := pr
+	updatedPr.State = manualCloseState
+	updatedPr.TerminalState = true
+	updatedPr.LastAction = getDbText(string(action))
+	updatedPr.LastActionOutcome = getDbText(ActionOutcomeSuccess)
+	updatedPr.LastActionResult = getDbText(string(events.EventStatusSuccess))
+	updatedPr.NeedsAttention = false
+	if config, configOk := actionMapping.getStateConfig(updatedPr); configOk {
+		updatedPr.NeedsAttention = config.needsAttention
+	}
+
+	updatedPr, err := a.prRepo.UpdatePatronRequest(ctx, pr_db.UpdatePatronRequestParams(updatedPr))
+	if err != nil {
+		return logActionErrorAndReturnResult(ctx, "failed to update patron request", err)
+	}
+
+	toState := string(updatedPr.State)
+	return events.EventStatusSuccess, &events.EventResult{
+		CommonEventData: events.CommonEventData{
+			ActionResult: &events.ActionResult{
+				Outcome: ActionOutcomeSuccess,
+				ToState: &toState,
+			},
+		},
 	}
 }
 

--- a/broker/patron_request/service/action_mapping.go
+++ b/broker/patron_request/service/action_mapping.go
@@ -50,6 +50,8 @@ type ActionMapping struct {
 	lenderStateActionMapping   map[pr_db.PatronRequestState][]PatronRequestAction
 	borrowerStateConfig        map[pr_db.PatronRequestState]stateConfig
 	lenderStateConfig          map[pr_db.PatronRequestState]stateConfig
+	borrowerManualCloseState   *pr_db.PatronRequestState
+	lenderManualCloseState     *pr_db.PatronRequestState
 }
 
 type stateConfig struct {
@@ -111,9 +113,17 @@ func NewActionMapping(stateModel *proapi.StateModel) *ActionMapping {
 		case proapi.REQUESTER:
 			borrowerMap[stateName] = actionEntries
 			borrowerConfig[stateName] = currentStateConfig
+			if state.ManualClose != nil && *state.ManualClose {
+				manualCloseState := stateName
+				r.borrowerManualCloseState = &manualCloseState
+			}
 		case proapi.SUPPLIER:
 			lenderMap[stateName] = actionEntries
 			lenderConfig[stateName] = currentStateConfig
+			if state.ManualClose != nil && *state.ManualClose {
+				manualCloseState := stateName
+				r.lenderManualCloseState = &manualCloseState
+			}
 		}
 	}
 
@@ -234,6 +244,24 @@ func (r *ActionMapping) GetAutoActionsForState(pr pr_db.PatronRequest) []pr_db.P
 		return []pr_db.PatronRequestAction{}
 	}
 	return append([]pr_db.PatronRequestAction{}, stateConfig.autoActions...)
+}
+
+func (r *ActionMapping) GetManualCloseState(pr pr_db.PatronRequest) (pr_db.PatronRequestState, bool) {
+	if pr.Side == SideBorrowing {
+		if r.borrowerManualCloseState == nil {
+			return "", false
+		}
+		return *r.borrowerManualCloseState, true
+	}
+	if r.lenderManualCloseState == nil {
+		return "", false
+	}
+	return *r.lenderManualCloseState, true
+}
+
+func (r *ActionMapping) IsTerminalState(pr pr_db.PatronRequest) bool {
+	stateConfig, ok := r.getStateConfig(pr)
+	return ok && stateConfig.terminal
 }
 
 func (r *ActionMapping) getStateConfig(pr pr_db.PatronRequest) (stateConfig, bool) {

--- a/broker/patron_request/service/action_mapping_test.go
+++ b/broker/patron_request/service/action_mapping_test.go
@@ -60,12 +60,14 @@ func TestIsActionAvailable(t *testing.T) {
 	// Borrower
 	assert.False(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideBorrowing, State: BorrowerStateNew}, BorrowerActionValidate))
 	assert.False(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideBorrowing, State: BorrowerStateNew}, BorrowerActionReceive))
+	assert.False(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideBorrowing, State: BorrowerStateValidated}, TerminateAction))
 
 	// Lender
 	assert.True(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideLending, State: LenderStateWillSupply}, LenderActionShip))
 	assert.True(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideLending, State: LenderStateConditionPending}, LenderActionAddCondition))
 	assert.True(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideLending, State: LenderStateConditionAccepted}, LenderActionAddCondition))
 	assert.False(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideLending, State: LenderStateWillSupply}, BorrowerActionRejectCondition))
+	assert.False(t, mapping.IsActionAvailable(pr_db.PatronRequest{Side: SideLending, State: LenderStateWillSupply}, TerminateAction))
 }
 
 func TestGetActionsForPatronRequest(t *testing.T) {
@@ -95,6 +97,37 @@ func TestGetActionsForPatronRequest(t *testing.T) {
 	listCompare(t, []pr_db.PatronRequestAction{LenderActionAddCondition, LenderActionCannotSupply}, mapping.GetActionsForPatronRequest(pr_db.PatronRequest{Side: SideLending, State: LenderStateConditionPending}))
 	listCompare(t, []pr_db.PatronRequestAction{LenderActionAddCondition, LenderActionCannotSupply, LenderActionShip}, mapping.GetActionsForPatronRequest(pr_db.PatronRequest{Side: SideLending, State: LenderStateConditionAccepted}))
 	listCompare(t, []pr_db.PatronRequestAction{}, mapping.GetActionsForPatronRequest(pr_db.PatronRequest{Side: SideLending, State: LenderStateShipped}))
+}
+
+func TestGetManualCloseState(t *testing.T) {
+	mapping := mustActionMapping(t)
+
+	state, ok := mapping.GetManualCloseState(pr_db.PatronRequest{Side: SideBorrowing})
+	assert.True(t, ok)
+	assert.Equal(t, BorrowerStateManuallyClosed, state)
+
+	state, ok = mapping.GetManualCloseState(pr_db.PatronRequest{Side: SideLending})
+	assert.True(t, ok)
+	assert.Equal(t, LenderStateManuallyClosed, state)
+}
+
+func TestGetManualCloseStateMissing(t *testing.T) {
+	tt := true
+	mapping := NewActionMapping(&proapi.StateModel{
+		Type:    proapi.StateModelTypeStateModel,
+		Name:    "test",
+		Version: "1.0.0",
+		States: []proapi.ModelState{
+			{
+				Name:     string(BorrowerStateCompleted),
+				Side:     proapi.REQUESTER,
+				Terminal: &tt,
+			},
+		},
+	})
+
+	_, ok := mapping.GetManualCloseState(pr_db.PatronRequest{Side: SideBorrowing})
+	assert.False(t, ok)
 }
 
 func TestGetAllowedActionsForPatronRequest1(t *testing.T) {

--- a/broker/patron_request/service/action_test.go
+++ b/broker/patron_request/service/action_test.go
@@ -98,6 +98,48 @@ func TestHandleInvokeActionNoLms(t *testing.T) {
 	assert.Equal(t, "LMS creator not configured", resultData.EventError.Message)
 }
 
+func TestHandleInvokeActionTerminateOKNoLms(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	prAction := CreatePatronRequestActionService(mockPrRepo, *new(events.EventBus), new(handler.Iso18626Handler), nil)
+	action := TerminateAction
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{
+		ID:            patronRequestId,
+		State:         BorrowerStateValidated,
+		Side:          SideBorrowing,
+		TerminalState: false,
+	}, nil)
+
+	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{CommonEventData: events.CommonEventData{Action: &action}}})
+
+	assert.Equal(t, events.EventStatusSuccess, status)
+	assert.NotNil(t, resultData)
+	assert.NotNil(t, resultData.ActionResult)
+	assert.Equal(t, ActionOutcomeSuccess, resultData.ActionResult.Outcome)
+	assert.Equal(t, string(BorrowerStateManuallyClosed), *resultData.ActionResult.ToState)
+	assert.Equal(t, BorrowerStateManuallyClosed, mockPrRepo.savedPr.State)
+	assert.True(t, mockPrRepo.savedPr.TerminalState)
+	assert.Equal(t, string(TerminateAction), mockPrRepo.savedPr.LastAction.String)
+	assert.Equal(t, ActionOutcomeSuccess, mockPrRepo.savedPr.LastActionOutcome.String)
+	assert.Equal(t, string(events.EventStatusSuccess), mockPrRepo.savedPr.LastActionResult.String)
+}
+
+func TestHandleInvokeActionTerminateRejectsTerminal(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	prAction := CreatePatronRequestActionService(mockPrRepo, *new(events.EventBus), new(handler.Iso18626Handler), nil)
+	action := TerminateAction
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{
+		ID:            patronRequestId,
+		State:         BorrowerStateCompleted,
+		Side:          SideBorrowing,
+		TerminalState: true,
+	}, nil)
+
+	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{CommonEventData: events.CommonEventData{Action: &action}}})
+
+	assert.Equal(t, events.EventStatusError, status)
+	assert.Equal(t, "patron request "+patronRequestId+" is already terminal", resultData.EventError.Message)
+}
+
 func TestHandleBorrowingActionMissingRequesterSymbol(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)

--- a/broker/patron_request/service/statemodel.go
+++ b/broker/patron_request/service/statemodel.go
@@ -86,6 +86,7 @@ func ValidateStateModel(stateModel *proapi.StateModel) error {
 		proapi.REQUESTER: {},
 		proapi.SUPPLIER:  {},
 	}
+	manualCloseStates := map[proapi.ModelStateSide]string{}
 	// Pass 1: validate all states and collect the state set defined in this model.
 	for _, state := range stateModel.States {
 		var builtInStates []string
@@ -105,6 +106,15 @@ func ValidateStateModel(stateModel *proapi.StateModel) error {
 			return fmt.Errorf("state %s is defined multiple times for side %s", state.Name, state.Side)
 		}
 		sideStates[state.Name] = struct{}{}
+		if state.ManualClose != nil && *state.ManualClose {
+			if state.Terminal == nil || !*state.Terminal {
+				return fmt.Errorf("manualClose state %s side %s must be terminal", state.Name, state.Side)
+			}
+			if existing, exists := manualCloseStates[state.Side]; exists {
+				return fmt.Errorf("manualClose state defined multiple times for side %s: %s and %s", state.Side, existing, state.Name)
+			}
+			manualCloseStates[state.Side] = state.Name
+		}
 	}
 
 	// Pass 2: validate actions/events and their transitions.

--- a/broker/patron_request/service/statemodel_capabilities.go
+++ b/broker/patron_request/service/statemodel_capabilities.go
@@ -36,6 +36,7 @@ const (
 	BorrowerStateCompleted        pr_db.PatronRequestState = "COMPLETED"
 	BorrowerStateCancelled        pr_db.PatronRequestState = "CANCELLED"
 	BorrowerStateUnfilled         pr_db.PatronRequestState = "UNFILLED"
+	BorrowerStateManuallyClosed   pr_db.PatronRequestState = "MANUALLY_CLOSED"
 	LenderStateNew                pr_db.PatronRequestState = "NEW"
 	LenderStateValidated          pr_db.PatronRequestState = "VALIDATED"
 	LenderStateWillSupply         pr_db.PatronRequestState = "WILL_SUPPLY"
@@ -48,6 +49,7 @@ const (
 	LenderStateCompleted          pr_db.PatronRequestState = "COMPLETED"
 	LenderStateCancelled          pr_db.PatronRequestState = "CANCELLED"
 	LenderStateUnfilled           pr_db.PatronRequestState = "UNFILLED"
+	LenderStateManuallyClosed     pr_db.PatronRequestState = "MANUALLY_CLOSED"
 )
 
 const (
@@ -69,6 +71,8 @@ const (
 	LenderActionShip         pr_db.PatronRequestAction = "ship"
 	LenderActionMarkReceived pr_db.PatronRequestAction = "mark-received"
 	LenderActionAcceptCancel pr_db.PatronRequestAction = "accept-cancel"
+
+	TerminateAction pr_db.PatronRequestAction = "terminate"
 )
 
 const (
@@ -104,6 +108,7 @@ func requesterBuiltInStates() []string {
 		string(BorrowerStateCompleted),
 		string(BorrowerStateCancelled),
 		string(BorrowerStateUnfilled),
+		string(BorrowerStateManuallyClosed),
 	})
 }
 
@@ -121,6 +126,7 @@ func supplierBuiltInStates() []string {
 		string(LenderStateCompleted),
 		string(LenderStateCancelled),
 		string(LenderStateUnfilled),
+		string(LenderStateManuallyClosed),
 	})
 }
 

--- a/broker/patron_request/service/statemodel_test.go
+++ b/broker/patron_request/service/statemodel_test.go
@@ -122,6 +122,73 @@ func TestValidateStateModelPrimaryActionNoActionsDefined(t *testing.T) {
 	assert.Equal(t, "primary action other undefined in state NEW side REQUESTER", err.Error())
 }
 
+func TestValidateStateModelManualCloseTerminal(t *testing.T) {
+	tt := true
+	model := &proapi.StateModel{
+		Type:    proapi.StateModelTypeStateModel,
+		Name:    "test",
+		Version: "1.0.0",
+		States: []proapi.ModelState{
+			{
+				Name:        string(BorrowerStateManuallyClosed),
+				Side:        proapi.REQUESTER,
+				Terminal:    &tt,
+				ManualClose: &tt,
+			},
+		},
+	}
+
+	err := ValidateStateModel(model)
+	assert.NoError(t, err)
+}
+
+func TestValidateStateModelManualCloseNonTerminal(t *testing.T) {
+	tt := true
+	model := &proapi.StateModel{
+		Type:    proapi.StateModelTypeStateModel,
+		Name:    "test",
+		Version: "1.0.0",
+		States: []proapi.ModelState{
+			{
+				Name:        string(BorrowerStateNew),
+				Side:        proapi.REQUESTER,
+				ManualClose: &tt,
+			},
+		},
+	}
+
+	err := ValidateStateModel(model)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be terminal")
+}
+
+func TestValidateStateModelManualCloseDuplicateSide(t *testing.T) {
+	tt := true
+	model := &proapi.StateModel{
+		Type:    proapi.StateModelTypeStateModel,
+		Name:    "test",
+		Version: "1.0.0",
+		States: []proapi.ModelState{
+			{
+				Name:        string(BorrowerStateCancelled),
+				Side:        proapi.REQUESTER,
+				Terminal:    &tt,
+				ManualClose: &tt,
+			},
+			{
+				Name:        string(BorrowerStateManuallyClosed),
+				Side:        proapi.REQUESTER,
+				Terminal:    &tt,
+				ManualClose: &tt,
+			},
+		},
+	}
+
+	err := ValidateStateModel(model)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "manualClose state defined multiple times")
+}
+
 func TestValidateStateModelInvalidRequesterAction(t *testing.T) {
 	model := &proapi.StateModel{
 		Type:    proapi.StateModelTypeStateModel,

--- a/broker/patron_request/service/statemodels/returnables.json
+++ b/broker/patron_request/service/statemodels/returnables.json
@@ -294,6 +294,14 @@
       "terminal": true
     },
     {
+      "name": "MANUALLY_CLOSED",
+      "display": "Manually closed",
+      "desc": "Closed manually by staff",
+      "side": "REQUESTER",
+      "terminal": true,
+      "manualClose": true
+    },
+    {
       "name": "NEW",
       "display": "New",
       "desc": "Item is created on the supplier side for local fulfillment",
@@ -547,6 +555,14 @@
       "desc": "After manual cannot-supply or automatically if auto-responder is on",
       "side": "SUPPLIER",
       "terminal": true
+    },
+    {
+      "name": "MANUALLY_CLOSED",
+      "display": "Manually closed",
+      "desc": "Closed manually by staff",
+      "side": "SUPPLIER",
+      "terminal": true,
+      "manualClose": true
     }
   ]
 }

--- a/misc/returnables.yaml
+++ b/misc/returnables.yaml
@@ -200,6 +200,13 @@ states:
     side: REQUESTER
     terminal: true
 
+  - name: MANUALLY_CLOSED
+    display: Manually closed
+    desc: Closed manually by staff
+    side: REQUESTER
+    terminal: true
+    manualClose: true
+
   # Supplier-side
   - name: NEW
     display: New
@@ -369,3 +376,10 @@ states:
     desc: After manual cannot-supply or automatically if auto-responder is on
     side: SUPPLIER
     terminal: true
+
+  - name: MANUALLY_CLOSED
+    display: Manually closed
+    desc: Closed manually by staff
+    side: SUPPLIER
+    terminal: true
+    manualClose: true


### PR DESCRIPTION
https://index-data.atlassian.net/browse/CROSSLINK-275

## Summary
- add special POST /patron_requests/{id}/terminate endpoint
- add manualClose terminal state metadata and MANUALLY_CLOSED returnables states
- process termination through invoke-action without exposing it as a normal action

## Tests
- go test ./patron_request/api ./patron_request/service
- go test ./app
- pre-push lint and Docker build hooks passed