### PR TITLE
CROSSLINK-302 Clean up supplier NCIP requests

### DIFF
--- a/broker/patron_request/service/action.go
+++ b/broker/patron_request/service/action.go
@@ -767,6 +767,12 @@ func (a *PatronRequestActionService) cancelLenderRequestItem(ctx common.Extended
 		return nil
 	}
 	requestId := illRequest.Header.RequestingAgencyRequestId
+	if requestId == "" {
+		return errors.New("missing RequestingAgencyRequestId for LMS CancelRequestItem")
+	}
+	if !pr.RequesterSymbol.Valid || pr.RequesterSymbol.String == "" {
+		return errors.New("invalid requester symbol")
+	}
 	userId := lmsAdapter.InstitutionalPatron(pr.RequesterSymbol.String)
 	return lmsAdapter.CancelRequestItem(requestId, userId)
 }

--- a/broker/patron_request/service/action.go
+++ b/broker/patron_request/service/action.go
@@ -414,7 +414,7 @@ func (a *PatronRequestActionService) handleLenderAction(ctx common.ExtendedConte
 	case LenderActionRejectCancel:
 		return a.rejectCancelLenderRequest(ctx, pr)
 	case LenderActionCannotSupply:
-		return a.cannotSupplyLenderRequest(ctx, pr, params)
+		return a.cannotSupplyLenderRequest(ctx, pr, lms, illRequest, params)
 	case LenderActionAddCondition:
 		return a.addConditionsLenderRequest(ctx, pr, params)
 	case LenderActionShip:
@@ -422,9 +422,9 @@ func (a *PatronRequestActionService) handleLenderAction(ctx common.ExtendedConte
 	case LenderActionMarkReceived:
 		return a.markReceivedLenderRequest(ctx, pr, lms)
 	case LenderActionAcceptCancel:
-		return a.acceptCancelLenderRequest(ctx, pr)
+		return a.acceptCancelLenderRequest(ctx, pr, lms, illRequest)
 	case LenderActionAskRetry:
-		return a.askRetryLenderRequest(ctx, pr, params)
+		return a.askRetryLenderRequest(ctx, pr, lms, illRequest, params)
 	case LenderActionSendNotification:
 		return a.sendNotificationLenderRequest(ctx, pr, params)
 	default:
@@ -738,6 +738,9 @@ func (a *PatronRequestActionService) willSupplyLenderRequest(ctx common.Extended
 		Barcode:    itemBarcode,
 	})
 	if err != nil {
+		if cancelErr := lmsAdapter.CancelRequestItem(requestId, userId); cancelErr != nil {
+			err = errors.Join(err, fmt.Errorf("LMS CancelRequestItem compensation failed: %w", cancelErr))
+		}
 		status, result := logActionErrorAndReturnResult(ctx, "failed to save item", err)
 		return actionExecutionResult{status: status, result: result, pr: pr}
 	}
@@ -755,7 +758,24 @@ func (a *PatronRequestActionService) willSupplyLenderRequest(ctx common.Extended
 	return a.checkSupplyingResponse(status, eventResult, &result, httpStatus, pr)
 }
 
-func (a *PatronRequestActionService) cannotSupplyLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest, params actionParams) actionExecutionResult {
+func (a *PatronRequestActionService) cancelLenderRequestItem(ctx common.ExtendedContext, pr pr_db.PatronRequest, lmsAdapter lms.LmsAdapter, illRequest iso18626.Request) error {
+	items, err := a.prRepo.GetItemsByPrId(ctx, pr.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get items: %w", err)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	requestId := illRequest.Header.RequestingAgencyRequestId
+	userId := lmsAdapter.InstitutionalPatron(pr.RequesterSymbol.String)
+	return lmsAdapter.CancelRequestItem(requestId, userId)
+}
+
+func (a *PatronRequestActionService) cannotSupplyLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest, lmsAdapter lms.LmsAdapter, illRequest iso18626.Request, params actionParams) actionExecutionResult {
+	if err := a.cancelLenderRequestItem(ctx, pr, lmsAdapter, illRequest); err != nil {
+		status, result := logActionErrorAndReturnResult(ctx, "LMS CancelRequestItem failed", err)
+		return actionExecutionResult{status: status, result: result, pr: pr}
+	}
 	result := events.EventResult{}
 	var reasonUnfilled *iso18626.TypeSchemeValuePair
 	if params.ReasonUnfilled != "" {
@@ -935,7 +955,11 @@ func (a *PatronRequestActionService) rejectCancelLenderRequest(ctx common.Extend
 	return a.checkSupplyingResponse(status, eventResult, &result, httpStatus, pr)
 }
 
-func (a *PatronRequestActionService) acceptCancelLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest) actionExecutionResult {
+func (a *PatronRequestActionService) acceptCancelLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest, lmsAdapter lms.LmsAdapter, illRequest iso18626.Request) actionExecutionResult {
+	if err := a.cancelLenderRequestItem(ctx, pr, lmsAdapter, illRequest); err != nil {
+		status, result := logActionErrorAndReturnResult(ctx, "LMS CancelRequestItem failed", err)
+		return actionExecutionResult{status: status, result: result, pr: pr}
+	}
 	yes := iso18626.TypeYesNoY
 	result := events.EventResult{}
 	status, eventResult, httpStatus := a.sendSupplyingAgencyMessage(ctx, pr, &result,
@@ -948,7 +972,7 @@ func (a *PatronRequestActionService) acceptCancelLenderRequest(ctx common.Extend
 	return a.checkSupplyingResponse(status, eventResult, &result, httpStatus, pr)
 }
 
-func (a *PatronRequestActionService) askRetryLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest, params actionParams) actionExecutionResult {
+func (a *PatronRequestActionService) askRetryLenderRequest(ctx common.ExtendedContext, pr pr_db.PatronRequest, lmsAdapter lms.LmsAdapter, illRequest iso18626.Request, params actionParams) actionExecutionResult {
 	var deliveryInfo *iso18626.DeliveryInfo
 	switch params.ReasonRetry {
 	case "":
@@ -964,6 +988,10 @@ func (a *PatronRequestActionService) askRetryLenderRequest(ctx common.ExtendedCo
 		}
 	default:
 		status, result := logActionErrorAndReturnResult(ctx, fmt.Sprintf("unsupported reasonRetry %q for ask-retry action (supported: %q)", params.ReasonRetry, iso18626.ReasonRetryNotFoundAsCited), nil)
+		return actionExecutionResult{status: status, result: result, pr: pr}
+	}
+	if err := a.cancelLenderRequestItem(ctx, pr, lmsAdapter, illRequest); err != nil {
+		status, result := logActionErrorAndReturnResult(ctx, "LMS CancelRequestItem failed", err)
 		return actionExecutionResult{status: status, result: result, pr: pr}
 	}
 	reasonRetry := iso18626.TypeSchemeValuePair{Text: params.ReasonRetry}

--- a/broker/patron_request/service/action_test.go
+++ b/broker/patron_request/service/action_test.go
@@ -1403,6 +1403,36 @@ func TestHandleInvokeLenderActionAskRetryFull(t *testing.T) {
 	}
 }
 
+func TestHandleInvokeLenderActionAskRetryCancelRequestItemFailed(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	lmsCreator := new(MockLmsCreator)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(errors.New("cancel failed"))
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
+	mockIso18626Handler := new(MockIso18626Handler)
+	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
+	action := LenderActionAskRetry
+
+	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{
+		CommonEventData: events.CommonEventData{Action: &action},
+		CustomData: map[string]any{
+			"itemId":      "0201896834",
+			"reasonRetry": string(iso18626.ReasonRetryNotFoundAsCited),
+		},
+	}})
+
+	assert.Equal(t, events.EventStatusError, status)
+	assert.Equal(t, "LMS CancelRequestItem failed", resultData.EventError.Message)
+	assert.Nil(t, mockIso18626Handler.lastSupplyingAgencyMessage)
+	assert.Equal(t, LenderStateValidated, mockPrRepo.savedPr.State)
+	assert.False(t, mockPrRepo.savedPr.TerminalState)
+	assert.True(t, mockPrRepo.savedPr.NeedsAttention)
+	lmsAdapter.AssertExpectations(t)
+}
+
 func TestHandleInvokeBorrowerActionAcceptRetryAutoActionCreateTaskError(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	mockEventBus := new(MockEventBus)
@@ -1828,6 +1858,30 @@ func TestHandleInvokeLenderActionAcceptCancel(t *testing.T) {
 	if assert.NotNil(t, mockIso18626Handler.lastSupplyingAgencyMessage.MessageInfo.AnswerYesNo) {
 		assert.Equal(t, iso18626.TypeYesNoY, *mockIso18626Handler.lastSupplyingAgencyMessage.MessageInfo.AnswerYesNo)
 	}
+}
+
+func TestHandleInvokeLenderActionAcceptCancelCancelRequestItemFailed(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	lmsCreator := new(MockLmsCreator)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(errors.New("cancel failed"))
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
+	mockIso18626Handler := new(MockIso18626Handler)
+	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateCancelRequested, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1"), RequesterReqID: getDbText("req-1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
+	action := LenderActionAcceptCancel
+
+	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{CommonEventData: events.CommonEventData{Action: &action}}})
+
+	assert.Equal(t, events.EventStatusError, status)
+	assert.Equal(t, "LMS CancelRequestItem failed", resultData.EventError.Message)
+	assert.Nil(t, mockIso18626Handler.lastSupplyingAgencyMessage)
+	assert.Equal(t, LenderStateCancelRequested, mockPrRepo.savedPr.State)
+	assert.False(t, mockPrRepo.savedPr.TerminalState)
+	assert.True(t, mockPrRepo.savedPr.NeedsAttention)
+	lmsAdapter.AssertExpectations(t)
 }
 
 func TestHandleInvokeLenderActionAcceptCancelMissingRequesterSymbol(t *testing.T) {

--- a/broker/patron_request/service/action_test.go
+++ b/broker/patron_request/service/action_test.go
@@ -1092,10 +1092,13 @@ func TestHandleInvokeLenderActionWillSupplyNcipFailed(t *testing.T) {
 func TestHandleInvokeLenderActionWillSupplySaveItemFailed(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)
-	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lms.CreateLmsAdapterMockOK(), nil)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("RequestItem", "req-1", "", "", "", "").Return("item-1", "", "", nil)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(nil)
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
 	mockIso18626Handler := new(MockIso18626Handler)
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
-	illRequest := iso18626.Request{}
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
 	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
 	mockPrRepo.saveItemFail = true
 	mockPrRepo.On("GetPatronRequestByIdForUpdate", patronRequestId).Return(pr_db.PatronRequest{RequesterSymbol: pgtype.Text{Valid: true, String: "ISIL:x"}, State: BorrowerStateNew, Side: SideBorrowing, Tenant: pgtype.Text{Valid: true, String: "testlib"}, IllRequest: illRequest}, nil)
@@ -1104,16 +1107,20 @@ func TestHandleInvokeLenderActionWillSupplySaveItemFailed(t *testing.T) {
 
 	assert.Equal(t, events.EventStatusError, status)
 	assert.Equal(t, "failed to save item", resultData.EventError.Message)
+	lmsAdapter.AssertExpectations(t)
 }
 
 func TestHandleInvokeLenderActionCannotSupply(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)
-	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lms.CreateLmsAdapterMockOK(), nil)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(nil)
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
 	mockIso18626Handler := new(MockIso18626Handler)
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
-	illRequest := iso18626.Request{}
-	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
 	action := LenderActionCannotSupply
 	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{
 		CommonEventData: events.CommonEventData{Action: &action},
@@ -1122,6 +1129,7 @@ func TestHandleInvokeLenderActionCannotSupply(t *testing.T) {
 	assert.Equal(t, events.EventStatusSuccess, status)
 	assert.NotNil(t, resultData)
 	assert.Equal(t, LenderStateUnfilled, mockPrRepo.savedPr.State)
+	lmsAdapter.AssertExpectations(t)
 
 	if assert.NotNil(t, mockIso18626Handler.lastSupplyingAgencyMessage) {
 		assert.Equal(t, iso18626.TypeStatusUnfilled, mockIso18626Handler.lastSupplyingAgencyMessage.StatusInfo.Status)
@@ -1139,7 +1147,8 @@ func TestHandleInvokeLenderActionCannotSupplyWithReason(t *testing.T) {
 	mockIso18626Handler := new(MockIso18626Handler)
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
 	illRequest := iso18626.Request{}
-	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{}, nil)
 	action := LenderActionCannotSupply
 	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{
 		CommonEventData: events.CommonEventData{Action: &action},
@@ -1162,6 +1171,31 @@ func TestHandleInvokeLenderActionCannotSupplyWithReason(t *testing.T) {
 			assert.Equal(t, "my reason", mockIso18626Handler.lastSupplyingAgencyMessage.MessageInfo.ReasonUnfilled.Text)
 		}
 	}
+}
+
+func TestHandleInvokeLenderActionCannotSupplyCancelRequestItemFailed(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	lmsCreator := new(MockLmsCreator)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(errors.New("cancel failed"))
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
+	mockIso18626Handler := new(MockIso18626Handler)
+	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
+	action := LenderActionCannotSupply
+
+	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{
+		CommonEventData: events.CommonEventData{Action: &action},
+	}})
+
+	assert.Equal(t, events.EventStatusError, status)
+	assert.Equal(t, "LMS CancelRequestItem failed", resultData.EventError.Message)
+	assert.Nil(t, mockIso18626Handler.lastSupplyingAgencyMessage)
+	assert.Equal(t, LenderStateValidated, mockPrRepo.savedPr.State)
+	assert.True(t, mockPrRepo.savedPr.NeedsAttention)
+	lmsAdapter.AssertExpectations(t)
 }
 
 func TestHandleInvokeLenderActionAddConditionOK(t *testing.T) {
@@ -1272,11 +1306,14 @@ func TestHandleInvokeLenderActionAskRetryMissingReasonRetry(t *testing.T) {
 func TestHandleInvokeLenderActionAskRetryFull(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)
-	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lms.CreateLmsAdapterMockOK(), nil)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(nil)
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
 	mockIso18626Handler := new(MockIso18626Handler)
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
-	illRequest := iso18626.Request{}
-	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
+	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateValidated, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
 	action := LenderActionAskRetry
 
 	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{
@@ -1290,6 +1327,7 @@ func TestHandleInvokeLenderActionAskRetryFull(t *testing.T) {
 	assert.Equal(t, events.EventStatusSuccess, status)
 	assert.NotNil(t, resultData)
 	assert.Equal(t, LenderStateCompletedWithRetry, mockPrRepo.savedPr.State)
+	lmsAdapter.AssertExpectations(t)
 
 	if assert.NotNil(t, mockIso18626Handler.lastSupplyingAgencyMessage) {
 		assert.Equal(t, iso18626.TypeStatusRetryPossible, mockIso18626Handler.lastSupplyingAgencyMessage.StatusInfo.Status)
@@ -1704,11 +1742,14 @@ func TestHandleInvokeLenderActionMarkReceivedLmsFailed(t *testing.T) {
 func TestHandleInvokeLenderActionAcceptCancel(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)
-	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lms.CreateLmsAdapterMockOK(), nil)
+	lmsAdapter := new(mockLmsAdapter)
+	lmsAdapter.On("CancelRequestItem", "req-1", "").Return(nil)
+	lmsCreator.On("GetAdapter", "ISIL:SUP1").Return(lmsAdapter, nil)
 	mockIso18626Handler := new(MockIso18626Handler)
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
-	illRequest := iso18626.Request{}
+	illRequest := iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}}
 	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateCancelRequested, Side: SideLending, SupplierSymbol: getDbText("ISIL:SUP1"), RequesterSymbol: getDbText("ISIL:REQ1"), RequesterReqID: getDbText("req-1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
 	action := LenderActionAcceptCancel
 
 	status, resultData := prAction.handleInvokeAction(appCtx, events.Event{PatronRequestID: patronRequestId, EventData: events.EventData{CommonEventData: events.CommonEventData{Action: &action}}})
@@ -1716,6 +1757,7 @@ func TestHandleInvokeLenderActionAcceptCancel(t *testing.T) {
 	assert.Equal(t, events.EventStatusSuccess, status)
 	assert.NotNil(t, resultData)
 	assert.Equal(t, LenderStateCancelled, mockPrRepo.savedPr.State)
+	lmsAdapter.AssertExpectations(t)
 	assert.NotNil(t, mockIso18626Handler.lastSupplyingAgencyMessage)
 	assert.Equal(t, iso18626.TypeReasonForMessageCancelResponse, mockIso18626Handler.lastSupplyingAgencyMessage.MessageInfo.ReasonForMessage)
 	assert.Equal(t, iso18626.TypeStatusCancelled, mockIso18626Handler.lastSupplyingAgencyMessage.StatusInfo.Status)
@@ -1733,6 +1775,7 @@ func TestHandleInvokeLenderActionAcceptCancelMissingRequesterSymbol(t *testing.T
 	prAction := CreatePatronRequestActionService(mockPrRepo, new(IllRepoMock), *new(events.EventBus), mockIso18626Handler, lmsCreator, new(EmailSenderMock))
 	illRequest := iso18626.Request{}
 	mockPrRepo.On("GetPatronRequestById", patronRequestId).Return(pr_db.PatronRequest{ID: patronRequestId, IllRequest: illRequest, State: LenderStateCancelRequested, Side: SideLending, RequesterSymbol: pgtype.Text{Valid: false, String: ""}, SupplierSymbol: getDbText("ISIL:SUP1")}, nil)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{}, nil)
 	mockPrRepo.On("GetPatronRequestByIdForUpdate", patronRequestId).Return(pr_db.PatronRequest{RequesterSymbol: pgtype.Text{Valid: true, String: "ISIL:x"}, State: BorrowerStateNew, Side: SideBorrowing, Tenant: pgtype.Text{Valid: true, String: "testlib"}, IllRequest: illRequest}, nil)
 	action := LenderActionAcceptCancel
 
@@ -2928,6 +2971,11 @@ func TestLoadReturnableStateModel(t *testing.T) {
 type mockLmsAdapter struct {
 	mock.Mock
 	lms.LmsAdapterManual
+}
+
+func (m *mockLmsAdapter) CancelRequestItem(requestId string, userId string) error {
+	args := m.Called(requestId, userId)
+	return args.Error(0)
 }
 
 func (m *mockLmsAdapter) CheckOutItem(

--- a/broker/patron_request/service/action_test.go
+++ b/broker/patron_request/service/action_test.go
@@ -1110,6 +1110,69 @@ func TestHandleInvokeLenderActionWillSupplySaveItemFailed(t *testing.T) {
 	lmsAdapter.AssertExpectations(t)
 }
 
+func TestCancelLenderRequestItemNoSavedItem(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{}, nil)
+	prAction := &PatronRequestActionService{prRepo: mockPrRepo}
+	lmsAdapter := new(mockLmsAdapter)
+
+	err := prAction.cancelLenderRequestItem(
+		appCtx,
+		pr_db.PatronRequest{ID: patronRequestId},
+		lmsAdapter,
+		iso18626.Request{},
+	)
+
+	assert.NoError(t, err)
+	lmsAdapter.AssertNotCalled(t, "CancelRequestItem", mock.Anything, mock.Anything)
+}
+
+func TestCancelLenderRequestItemMissingRequestID(t *testing.T) {
+	mockPrRepo := new(MockPrRepo)
+	mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
+	prAction := &PatronRequestActionService{prRepo: mockPrRepo}
+	lmsAdapter := new(mockLmsAdapter)
+
+	err := prAction.cancelLenderRequestItem(
+		appCtx,
+		pr_db.PatronRequest{ID: patronRequestId, RequesterSymbol: getDbText("ISIL:REQ1")},
+		lmsAdapter,
+		iso18626.Request{},
+	)
+
+	assert.EqualError(t, err, "missing RequestingAgencyRequestId for LMS CancelRequestItem")
+	lmsAdapter.AssertNotCalled(t, "CancelRequestItem", mock.Anything, mock.Anything)
+}
+
+func TestCancelLenderRequestItemInvalidRequesterSymbol(t *testing.T) {
+	tests := []struct {
+		name   string
+		symbol pgtype.Text
+	}{
+		{name: "not valid"},
+		{name: "empty", symbol: getDbText("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPrRepo := new(MockPrRepo)
+			mockPrRepo.On("GetItemsByPrId", patronRequestId).Return([]pr_db.Item{{Barcode: "item-1"}}, nil)
+			prAction := &PatronRequestActionService{prRepo: mockPrRepo}
+			lmsAdapter := new(mockLmsAdapter)
+
+			err := prAction.cancelLenderRequestItem(
+				appCtx,
+				pr_db.PatronRequest{ID: patronRequestId, RequesterSymbol: tt.symbol},
+				lmsAdapter,
+				iso18626.Request{Header: iso18626.Header{RequestingAgencyRequestId: "req-1"}},
+			)
+
+			assert.EqualError(t, err, "invalid requester symbol")
+			lmsAdapter.AssertNotCalled(t, "CancelRequestItem", mock.Anything, mock.Anything)
+		})
+	}
+}
+
 func TestHandleInvokeLenderActionCannotSupply(t *testing.T) {
 	mockPrRepo := new(MockPrRepo)
 	lmsCreator := new(MockLmsCreator)


### PR DESCRIPTION
https://index-data.atlassian.net/browse/CROSSLINK-302

Cancel RequestItem before ask-retry, cannot-supply, and accept-cancel when a supplier request exists.
Compensate when saving the item after RequestItem fails.

Leave CheckOutItem/CheckInItem and manual termination flows unchanged.